### PR TITLE
flexible config options (closes #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ fargate
 dist
 vendor
 Dockerfile.build
+fargate.yml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,7 +28,6 @@
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
-    "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
     "service/acm",
     "service/acm/acmiface",
@@ -39,13 +38,16 @@
     "service/ecs",
     "service/elbv2",
     "service/elbv2/elbv2iface",
-    "service/iam",
-    "service/route53",
-    "service/route53/route53iface",
     "service/sts"
   ]
   revision = "1b176c5c6b57adb03bb982c21930e708ebca5a77"
   version = "v1.12.70"
+
+[[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   name = "github.com/go-ini/ini"
@@ -68,6 +70,23 @@
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -83,6 +102,12 @@
   packages = ["."]
   revision = "7e06b236c489543f53868841f188a294e3383eab"
   version = "v1.5"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -103,15 +128,54 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "ccaecb155a2177302cb56cae929251a256d0f646"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"
@@ -135,14 +199,27 @@
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
-  branch = "master"
-  name = "golang.org/x/time"
-  packages = ["rate"]
-  revision = "6dc17368e09b0e8634d71cac8168d853e869a0c7"
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8677694b9e080fee43d6d400a5650f7a2d4d80186bbe79740b6d8568f6ea116c"
+  inputs-digest = "47f49ac4660a0b96b8f7f9ed7b584520f064fc27a3103e681692a09ca98074a3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,26 +1,3 @@
-
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
-
-
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "1.12.70"
@@ -50,5 +27,5 @@
   name = "golang.org/x/crypto"
 
 [[constraint]]
-  branch = "master"
-  name = "golang.org/x/time"
+  name = "github.com/spf13/viper"
+  version = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the AWS SDK for Go documentation.
 
 #### Options
 
-There are several ways to specify parameters.  Each item takes precendence over the item below it:
+There are several ways to specify parameters.  Each item takes precedence over the item below it:
 
 1. CLI arguments (e.g., `--cluster my-cluster`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fargate CLI
 
-CLI for [AWS Fargate](https://aws.amazon.com/fargate/)
+Deploy serverless containers to the cloud from your command line
 
 [![CircleCI](https://circleci.com/gh/turnerlabs/fargate/tree/master.svg?style=svg)](https://circleci.com/gh/turnerlabs/fargate/tree/master)
 [![GoDoc](https://godoc.org/github.com/turnerlabs/fargate?status.svg)](https://godoc.org/github.com/turnerlabs/fargate)
@@ -34,18 +34,35 @@ in the following locations:
 For more information see [Specifying Credentials][go-specifying-credentials] in
 the AWS SDK for Go documentation.
 
-### Commands
+#### Options
 
-- [Services](#services)
+There are several ways to specify parameters.  Each item takes precendence over the item below it:
+
+1. CLI arguments (e.g., `--cluster my-cluster`)
+
+1. Environment Variables (e.g., `FARGATE_CLUSTER=my-cluster`)
+
+1. `fargate.yml` (e.g., below)
+
+```yaml
+cluster: my-cluster
+service: my-service
+verbose: false
+nocolor: true
+```
 
 #### Global Flags
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| --cluster | fargate | ECS cluster name |
-| --region | us-east-1 | AWS region |
-| --no-color | false | Disable color output |
-| --verbose | false | Verbose output |
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| --cluster | -c | | ECS cluster name |
+| --region | | us-east-1 | AWS region |
+| --no-color | | false | Disable color output |
+| --verbose | -v | false | Verbose output |
+
+### Commands
+
+- [Services](#services)
 
 #### Services
 
@@ -67,6 +84,12 @@ distribute traffic amongst the tasks in your service.
 - [update](#fargate-service-update)
 - [restart](#fargate-service-restart)
 
+##### Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| --service | -s | | ECS service name |
+
 ##### fargate service list
 
 ```console
@@ -75,20 +98,10 @@ fargate service list
 
 List services
 
-##### fargate service create
-
-```console
-fargate service create <service name> [--cpu <cpu units>] [--memory <MiB>] [--port <port-expression>]
-                                      [--lb <load-balancer-name>] [--rule <rule-expression>]
-                                      [--image <docker-image>] [--env <key=value>] [--num <count>]
-                                      [--task-role <task-role>] [--subnet-id <subnet-id>]
-                                      [--security-group-id <security-group-id>]
-```
-
 ##### fargate service deploy
 
 ```console
-fargate service deploy <service-name> [--image <docker-image>]
+fargate service deploy [--image <docker-image>]
 ```
 
 Deploy new image to service
@@ -103,7 +116,7 @@ HEAD commit. If not, a timestamp in the format of YYYYMMDDHHMMSS will be used.
 ##### fargate service info
 
 ```console
-fargate service info <service-name>
+fargate service info 
 ```
 
 Inspect service
@@ -118,8 +131,8 @@ update to configuration such a CPU, memory, or environment variables.
 ##### fargate service logs
 
 ```console
-fargate service logs <service-name> [--follow] [--start <time-expression>] [--end <time-expression>]
-                                    [--filter <filter-expression>] [--task <task-id>]
+fargate service logs [--follow] [--start <time-expression>] [--end <time-expression>]
+                     [--filter <filter-expression>] [--task <task-id>]
 ```
 
 Show logs from tasks in a service
@@ -152,7 +165,7 @@ documentation][cwl-filter-expression] for more details.
 ##### fargate service ps
 
 ```console
-fargate service ps <service-name>
+fargate service ps
 ```
 
 List running tasks for a service
@@ -160,7 +173,7 @@ List running tasks for a service
 ##### fargate service scale
 
 ```console
-fargate service scale <service-name> <scale-expression>
+fargate service scale <scale-expression>
 ```
 
 Scale number of tasks in a service
@@ -172,7 +185,7 @@ specified with a sign such as +5 or -2.
 ##### fargate service env set
 
 ```console
-fargate service env set <service-name> --env <key=value>
+fargate service env set --env <key=value>
 ```
 
 Set environment variables
@@ -183,7 +196,7 @@ At least one environment variable must be specified via the --env flag. Specify
 ##### fargate service env unset
 
 ```console
-fargate service env unset <service-name> --key <key-name>
+fargate service env unset --key <key-name>
 ```
 
 Unset environment variables
@@ -194,15 +207,20 @@ a key name multiple times to unset multiple variables.
 ##### fargate service env list
 
 ```console
-fargate service env list <service-name>
+fargate service env list
 ```
 
 Show environment variables
 
 ##### fargate service update
 
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| --cpu | | | Amount of cpu units to allocate for each task |
+| --memory | -m | | Amount of MiB to allocate for each task |
+
 ```console
-fargate service update <service-name> [--cpu <cpu-units>] [--memory <MiB>]
+fargate service update [--cpu <cpu-units>] [--memory <MiB>]
 ```
 
 Update service configuration
@@ -225,7 +243,7 @@ At least one of --cpu or --memory must be specified.
 ##### fargate service restart
 
 ```console
-fargate service restart <service-name>
+fargate service restart 
 ```
 
 Restart service

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	keyCluster = "cluster"
+	keyService = "service"
+	keyVerbose = "verbose"
+	keyNoColor = "nocolor"
+)
+
+//configure viper to manage parameter input
+func initConfig(cmd *cobra.Command) {
+
+	//config file
+	viper.SetConfigName("fargate")
+	viper.AddConfigPath("./")
+	viper.ReadInConfig()
+
+	//env vars
+	viper.BindEnv(keyCluster, "FARGATE_CLUSTER")
+	viper.BindEnv(keyService, "FARGATE_SERVICE")
+	viper.BindEnv(keyVerbose, "FARGATE_VERBOSE")
+	viper.BindEnv(keyNoColor, "FARGATE_NOCOLOR")
+
+	//cli arg
+	initPFlag(keyCluster, cmd)
+	initPFlag(keyVerbose, cmd)
+	initPFlag(keyNoColor, cmd)
+}
+
+func initPFlag(key string, cmd *cobra.Command) {
+	viper.BindPFlag(key, cmd.PersistentFlags().Lookup(key))
+}
+
+//cluster can come from fargate.yml, FARGATE_CLUSTER envar, or --cluster cli arg
+func getClusterName() string {
+	result := viper.GetString(keyCluster)
+	if result == "" {
+		fmt.Println("please specify cluster using: fargate.yml, FARGATE_SERVICE envvar, or --cluster")
+		os.Exit(-1)
+	}
+	return result
+}
+
+//service can come from fargate.yml, FARGATE_SERVICE, or --service cli arg
+func getServiceName() string {
+	result := viper.GetString(keyService)
+	if result == "" {
+		fmt.Println("please specify service using: fargate.yml, FARGATE_SERVICE envvar, or --service")
+		os.Exit(-1)
+	}
+	return result
+}
+
+func getVerbose() bool {
+	return viper.GetBool(keyVerbose)
+}
+
+func getNoColor() bool {
+	return viper.GetBool(keyNoColor)
+}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -18,6 +18,12 @@ tasks running. Services can be used in concert with a load balancer to
 distribute traffic amongst the tasks in your service.`,
 }
 
+var serviceName string
+
 func init() {
 	rootCmd.AddCommand(serviceCmd)
+
+	serviceCmd.PersistentFlags().StringVarP(&serviceName, "service", "s", "", `ECS service name`)
+
+	initPFlag(keyService, serviceCmd)
 }

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -17,7 +17,7 @@ type ServiceDeployOperation struct {
 var flagServiceDeployImage string
 
 var serviceDeployCmd = &cobra.Command{
-	Use:   "deploy <service-name>",
+	Use:   "deploy",
 	Short: "Deploy new image to service",
 	Long: `Deploy new image to service
 
@@ -27,10 +27,9 @@ container image from the current working directory and push it to Amazon ECR in
 a repository named for the task group. If the current working directory is a
 git repository, the container image will be tagged with the short ref of the
 HEAD commit. If not, a timestamp in the format of YYYYMMDDHHMMSS will be used.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceDeployOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 			Image:       flagServiceDeployImage,
 		}
 
@@ -45,7 +44,7 @@ func init() {
 }
 
 func deployService(operation *ServiceDeployOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	service := ecs.DescribeService(operation.ServiceName)
 
 	if operation.Image == "" {

--- a/cmd/service_env_list.go
+++ b/cmd/service_env_list.go
@@ -11,12 +11,11 @@ type ServiceEnvListOperation struct {
 }
 
 var serviceEnvListCmd = &cobra.Command{
-	Use:   "list <service-name>",
+	Use:   "list",
 	Short: "Show environment variables",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvListOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
 		serviceEnvList(operation)
@@ -28,7 +27,7 @@ func init() {
 }
 
 func serviceEnvList(operation *ServiceEnvListOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	service := ecs.DescribeService(operation.ServiceName)
 	envVars := ecs.GetEnvVarsFromTaskDefinition(service.TaskDefinitionArn)
 

--- a/cmd/service_env_set.go
+++ b/cmd/service_env_set.go
@@ -30,10 +30,9 @@ var serviceEnvSetCmd = &cobra.Command{
 
 At least one environment variable must be specified via the --env flag. Specify
 --env with a key=value parameter multiple times to add multiple variables.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvSetOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
 		operation.SetEnvVars(flagServiceEnvSetEnvVars)
@@ -49,7 +48,7 @@ func init() {
 }
 
 func serviceEnvSet(operation *ServiceEnvSetOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	service := ecs.DescribeService(operation.ServiceName)
 	taskDefinitionArn := ecs.AddEnvVarsToTaskDefinition(service.TaskDefinitionArn, operation.EnvVars)
 

--- a/cmd/service_env_unset.go
+++ b/cmd/service_env_unset.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/turnerlabs/fargate/console"
 	ECS "github.com/turnerlabs/fargate/ecs"
-	"github.com/spf13/cobra"
 )
 
 type ServiceEnvUnsetOperation struct {
@@ -30,10 +30,9 @@ var serviceEnvUnsetCmd = &cobra.Command{
 
 Unsets the environment variable specified via the --key flag. Specify --key with
 a key name multiple times to unset multiple variables.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvUnsetOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
 		operation.SetKeys(flagServiceEnvUnsetKeys)
@@ -51,7 +50,7 @@ func init() {
 }
 
 func serviceEnvUnset(operation *ServiceEnvUnsetOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	service := ecs.DescribeService(operation.ServiceName)
 	taskDefinitionArn := ecs.RemoveEnvVarsFromTaskDefinition(service.TaskDefinitionArn, operation.Keys)
 

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -22,7 +22,7 @@ type ServiceInfoOperation struct {
 }
 
 var serviceInfoCmd = &cobra.Command{
-	Use:   "info <service-name>",
+	Use:   "info",
 	Short: "Inspect service",
 	Long: `Inspect service
 
@@ -32,10 +32,9 @@ active deployments, and environment variables.
 Deployments show active versions of your service that are running. Multiple
 deployments are shown if a service is transitioning due to a deployment or
 update to configuration such a CPU, memory, or environment variables.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceInfoOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
 		getServiceInfo(operation)
@@ -50,7 +49,7 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 	var eniIds []string
 
 	acm := ACM.New(sess)
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	ec2 := EC2.New(sess)
 	elbv2 := ELBV2.New(sess)
 	service := ecs.DescribeService(operation.ServiceName)
@@ -180,7 +179,7 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 		for i, event := range service.Events {
 			fmt.Printf("[%s] %s\n", event.CreatedAt, event.Message)
 
-			if i == 10 && !verbose {
+			if i == 10 && !getVerbose() {
 				break
 			}
 		}

--- a/cmd/service_list.go
+++ b/cmd/service_list.go
@@ -30,7 +30,7 @@ func listServices() {
 	targetGroups := make(map[string]ELBV2.TargetGroup)
 	loadBalancers := make(map[string]ELBV2.LoadBalancer)
 
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	elbv2 := ELBV2.New(sess)
 	services := ecs.ListServices()
 

--- a/cmd/service_logs.go
+++ b/cmd/service_logs.go
@@ -15,7 +15,7 @@ var (
 )
 
 var serviceLogsCmd = &cobra.Command{
-	Use:   "logs <service-name>",
+	Use:   "logs",
 	Short: "Show logs from tasks in a service",
 	Long: `Show logs from tasks in a service
 
@@ -42,15 +42,14 @@ timestamp:
 You can filter logs for specific term by passing a filter expression via the
 --filter flag. Pass a single term to search for that term, pass multiple terms
 to search for log messages that include all terms.`,
-	Args: cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &GetLogsOperation{
-			LogGroupName: fmt.Sprintf(serviceLogGroupFormat, args[0]),
+			LogGroupName: fmt.Sprintf(serviceLogGroupFormat, getServiceName()),
 			Filter:       flagServiceLogsFilter,
 			Follow:       flagServiceLogsFollow,
-			Namespace:    args[0],
+			Namespace:    getServiceName(),
 		}
 
 		operation.AddTasks(flagServiceLogsTasks)

--- a/cmd/service_ps.go
+++ b/cmd/service_ps.go
@@ -16,12 +16,11 @@ type ServiceProcessListOperation struct {
 }
 
 var servicePsCmd = &cobra.Command{
-	Use:   "ps <service-name>",
+	Use:   "ps",
 	Short: "List running tasks for a service",
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceProcessListOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
 		getServiceProcessList(operation)
@@ -35,7 +34,7 @@ func init() {
 func getServiceProcessList(operation *ServiceProcessListOperation) {
 	var eniIds []string
 
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	ec2 := EC2.New(sess)
 	tasks := ecs.DescribeTasksForService(operation.ServiceName)
 

--- a/cmd/service_restart.go
+++ b/cmd/service_restart.go
@@ -11,17 +11,16 @@ type ServiceRestartOperation struct {
 }
 
 var serviceRestartCmd = &cobra.Command{
-	Use:   "restart <service-name>",
+	Use:   "restart",
 	Short: "Restart service",
 	Long: `Restart service
 
 Creates a new set of tasks for the service and stops the previous tasks. This
 is useful if your service needs to reload data cached from an external source,
 for example.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceRestartOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
 		restartService(operation)
@@ -33,7 +32,7 @@ func init() {
 }
 
 func restartService(operation *ServiceRestartOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 
 	ecs.RestartService(operation.ServiceName)
 	console.Info("Restarted %s", operation.ServiceName)

--- a/cmd/service_scale.go
+++ b/cmd/service_scale.go
@@ -18,7 +18,7 @@ type ScaleServiceOperation struct {
 }
 
 func (o *ScaleServiceOperation) SetScale(scaleExpression string) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 	validScale := regexp.MustCompile(validScalePattern)
 
 	if !validScale.MatchString(scaleExpression) {
@@ -46,20 +46,20 @@ func (o *ScaleServiceOperation) SetScale(scaleExpression string) {
 }
 
 var serviceScaleCmd = &cobra.Command{
-	Use:   "scale <service-name> <scale-expression>",
+	Use:   "scale <scale-expression>",
 	Short: "Changes the number of tasks running for the service",
 	Long: `Scale number of tasks in a service
 
 Changes the number of desired tasks to be run in a service by the given scale
 expression. A scale expression can either be an absolute number or a delta
 specified with a sign such as +5 or -2.`,
-	Args: cobra.ExactArgs(2),
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ScaleServiceOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 		}
 
-		operation.SetScale(args[1])
+		operation.SetScale(args[0])
 
 		scaleService(operation)
 	},
@@ -70,7 +70,7 @@ func init() {
 }
 
 func scaleService(operation *ScaleServiceOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 
 	ecs.SetDesiredCount(operation.ServiceName, operation.DesiredCount)
 	console.Info("Scaled service %s to %d", operation.ServiceName, operation.DesiredCount)

--- a/cmd/service_update.go
+++ b/cmd/service_update.go
@@ -16,7 +16,7 @@ type ServiceUpdateOperation struct {
 }
 
 func (o *ServiceUpdateOperation) Validate() {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 
 	if o.Cpu == "" && o.Memory == "" {
 		console.ErrorExit(fmt.Errorf("--cpu and/or --memory must be supplied"), "Invalid command line arguments")
@@ -46,7 +46,7 @@ var (
 )
 
 var serviceUpdateCmd = &cobra.Command{
-	Use:   "update <service-name> --cpu <cpu-units> | --memory <MiB>",
+	Use:   "update --cpu <cpu-units> | --memory <MiB>",
 	Short: "Update service configuration",
 	Long: `Update service configuration
 
@@ -64,10 +64,9 @@ configurations:
 | 4096            | 8192 through 30720 in 1GiB increments |
 
 At least one of --cpu or --memory must be specified.`,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceUpdateOperation{
-			ServiceName: args[0],
+			ServiceName: getServiceName(),
 			Cpu:         flagServiceUpdateCpu,
 			Memory:      flagServiceUpdateMemory,
 		}
@@ -81,12 +80,12 @@ At least one of --cpu or --memory must be specified.`,
 func init() {
 	serviceCmd.AddCommand(serviceUpdateCmd)
 
-	serviceUpdateCmd.Flags().StringVarP(&flagServiceUpdateCpu, "cpu", "c", "", "Amount of cpu units to allocate for each task")
+	serviceUpdateCmd.Flags().StringVar(&flagServiceUpdateCpu, "cpu", "", "Amount of cpu units to allocate for each task")
 	serviceUpdateCmd.Flags().StringVarP(&flagServiceUpdateMemory, "memory", "m", "", "Amount of MiB to allocate for each task")
 }
 
 func updateService(operation *ServiceUpdateOperation) {
-	ecs := ECS.New(sess, clusterName)
+	ecs := ECS.New(sess, getClusterName())
 
 	newTaskDefinitionArn := ecs.UpdateTaskDefinitionCpuAndMemory(
 		operation.Service.TaskDefinitionArn,


### PR DESCRIPTION
From the readme...

There are several ways to specify parameters.  Each item takes precedence over the item below it:

1. CLI arguments (e.g., `--cluster my-cluster`, `--service my-service`)

1. Environment Variables (e.g., `FARGATE_CLUSTER=my-cluster`, `FARGATE_SERVICE=my-service`)

1. `fargate.yml` (e.g., below)

```yaml
cluster: my-cluster
service: my-service
verbose: false
nocolor: true
```