### PR TITLE
add service discovery to service info cmd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:b9d50df07b2593c0173146461dd240513699c9afb18381adf51c3b1e92951d86"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -14,12 +15,16 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
@@ -34,43 +39,53 @@
     "service/cloudwatchlogs",
     "service/ec2",
     "service/ec2/ec2iface",
-    "service/ecr",
     "service/ecs",
     "service/elbv2",
     "service/elbv2/elbv2iface",
-    "service/sts"
+    "service/servicediscovery",
+    "service/sts",
   ]
-  revision = "1b176c5c6b57adb03bb982c21930e708ebca5a77"
-  version = "v1.12.70"
+  pruneopts = ""
+  revision = "ca229c7730be9278527fbb287f5a26c91e328d86"
+  version = "v1.15.15"
 
 [[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = ""
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:a00483fe4106b86fb1187a92b5cf6915c85f294ed4c129ccbe7cb1f1a06abd46"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
   version = "v1.32.0"
 
 [[projects]]
+  digest = "1:85e195bd952faa2e720f5c371d0993af6d515cfcda3894de9caf5c896165cd8c"
   name = "github.com/golang/mock"
   packages = ["gomock"]
+  pruneopts = ""
   revision = "b3e60bcdc577185fce3cf625fc96b62857ce5574"
 
 [[projects]]
   branch = "master"
+  digest = "1:9c776d7d9c54b7ed89f119e449983c3f24c0023e75001d6092442412ebca6b94"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = ""
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:9b7c5846d70f425d7fe279595e32a20994c6075e87be03b5c367ed07280877c5"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -82,123 +97,161 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = ""
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:7089a8fdbe330c9ea88af46acacec584f11d8aa4736080ff4bd96bb0b407dcd1"
   name = "github.com/kyokomi/emoji"
   packages = ["."]
+  pruneopts = ""
   revision = "7e06b236c489543f53868841f188a294e3383eab"
   version = "v1.5"
 
 [[projects]]
+  digest = "1:d244eb7b2d8e9f4c9355d215d65159c176603874ba10bfb7cbe6dcbd212813f5"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = ""
   revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
   version = "v1.7.6"
 
 [[projects]]
+  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:50416da10e189bc201e122e20078fb8e680a439cbdd24aaece06c434b4415b60"
   name = "github.com/mgutz/ansi"
   packages = ["."]
+  pruneopts = ""
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
   branch = "master"
+  digest = "1:59fa50d593e5673a0dfffa1852b66fd700c05b35e368680b4b89a68fdb2c1379"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
+  digest = "1:d60cfeee185019d4fcd35e8c89c83aff576e4723b6100300bf67b05be961388f"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:d3e2e29bc7342053edc85e1ad751275694a96d58516f749cf3413db1a0eca2ba"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
+  pruneopts = ""
   revision = "63644898a8da0bc22138abf860edaf5277b6102e"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:d0b38ba6da419a6d4380700218eeec8623841d44a856bb57369c172fbf692ab4"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:23376ec6b30060d1659debd1b9ca73d6037269a5b169402ccd42914edd04b5ec"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "ccaecb155a2177302cb56cae929251a256d0f646"
 
 [[projects]]
   branch = "master"
+  digest = "1:104517520aab91164020ab6524a5d6b7cafc641b2e42ac6236f6ac1deac4f66a"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = ""
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
+  digest = "1:261bc565833ef4f02121450d74eb88d5ae4bd74bfe5d0e862cddb8550ec35000"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:3dab237cd3263a290d771d133fed777bb56c22e380b00ebe92e6531d5c8d3d0c"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = ""
   revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
   version = "v1.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:febc7d7c1a817016b83441742910a3eab682d5c64613fcd91fde7ca06107ea49"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
 
 [[projects]]
   branch = "master"
+  digest = "1:e8c91565d4707bd93aa70e096884ce533acc5deb2bbb500bb064f49de70acda0"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = ""
   revision = "2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1"
 
 [[projects]]
   branch = "master"
+  digest = "1:407b5f905024dd94ee08c1777fabb380fb3d380f92a7f7df2592be005337eeb3"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -206,20 +259,45 @@
     "internal/ucd",
     "transform",
     "unicode/cldr",
-    "unicode/norm"
+    "unicode/norm",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "47f49ac4660a0b96b8f7f9ed7b584520f064fc27a3103e681692a09ca98074a3"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/request",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/acm",
+    "github.com/aws/aws-sdk-go/service/acm/acmiface",
+    "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
+    "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/ec2/ec2iface",
+    "github.com/aws/aws-sdk-go/service/ecs",
+    "github.com/aws/aws-sdk-go/service/elbv2",
+    "github.com/aws/aws-sdk-go/service/elbv2/elbv2iface",
+    "github.com/aws/aws-sdk-go/service/servicediscovery",
+    "github.com/golang/mock/gomock",
+    "github.com/hashicorp/golang-lru",
+    "github.com/kyokomi/emoji",
+    "github.com/mgutz/ansi",
+    "github.com/spf13/cobra",
+    "github.com/spf13/viper",
+    "golang.org/x/crypto/ssh/terminal",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.12.70"
+  version = "1.15.15"
 
 [[constraint]]
   name = "github.com/golang/mock"

--- a/acm/mock/sdk/acmiface.go
+++ b/acm/mock/sdk/acmiface.go
@@ -167,6 +167,50 @@ func (mr *MockACMAPIMockRecorder) DescribeCertificateRequest(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCertificateRequest", reflect.TypeOf((*MockACMAPI)(nil).DescribeCertificateRequest), arg0)
 }
 
+// ExportCertificate mocks base method
+func (m *MockACMAPI) ExportCertificate(arg0 *acm.ExportCertificateInput) (*acm.ExportCertificateOutput, error) {
+	ret := m.ctrl.Call(m, "ExportCertificate", arg0)
+	ret0, _ := ret[0].(*acm.ExportCertificateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportCertificate indicates an expected call of ExportCertificate
+func (mr *MockACMAPIMockRecorder) ExportCertificate(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportCertificate", reflect.TypeOf((*MockACMAPI)(nil).ExportCertificate), arg0)
+}
+
+// ExportCertificateWithContext mocks base method
+func (m *MockACMAPI) ExportCertificateWithContext(arg0 aws.Context, arg1 *acm.ExportCertificateInput, arg2 ...request.Option) (*acm.ExportCertificateOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExportCertificateWithContext", varargs...)
+	ret0, _ := ret[0].(*acm.ExportCertificateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportCertificateWithContext indicates an expected call of ExportCertificateWithContext
+func (mr *MockACMAPIMockRecorder) ExportCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportCertificateWithContext", reflect.TypeOf((*MockACMAPI)(nil).ExportCertificateWithContext), varargs...)
+}
+
+// ExportCertificateRequest mocks base method
+func (m *MockACMAPI) ExportCertificateRequest(arg0 *acm.ExportCertificateInput) (*request.Request, *acm.ExportCertificateOutput) {
+	ret := m.ctrl.Call(m, "ExportCertificateRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*acm.ExportCertificateOutput)
+	return ret0, ret1
+}
+
+// ExportCertificateRequest indicates an expected call of ExportCertificateRequest
+func (mr *MockACMAPIMockRecorder) ExportCertificateRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportCertificateRequest", reflect.TypeOf((*MockACMAPI)(nil).ExportCertificateRequest), arg0)
+}
+
 // GetCertificate mocks base method
 func (m *MockACMAPI) GetCertificate(arg0 *acm.GetCertificateInput) (*acm.GetCertificateOutput, error) {
 	ret := m.ctrl.Call(m, "GetCertificate", arg0)
@@ -502,4 +546,77 @@ func (m *MockACMAPI) ResendValidationEmailRequest(arg0 *acm.ResendValidationEmai
 // ResendValidationEmailRequest indicates an expected call of ResendValidationEmailRequest
 func (mr *MockACMAPIMockRecorder) ResendValidationEmailRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResendValidationEmailRequest", reflect.TypeOf((*MockACMAPI)(nil).ResendValidationEmailRequest), arg0)
+}
+
+// UpdateCertificateOptions mocks base method
+func (m *MockACMAPI) UpdateCertificateOptions(arg0 *acm.UpdateCertificateOptionsInput) (*acm.UpdateCertificateOptionsOutput, error) {
+	ret := m.ctrl.Call(m, "UpdateCertificateOptions", arg0)
+	ret0, _ := ret[0].(*acm.UpdateCertificateOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCertificateOptions indicates an expected call of UpdateCertificateOptions
+func (mr *MockACMAPIMockRecorder) UpdateCertificateOptions(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCertificateOptions", reflect.TypeOf((*MockACMAPI)(nil).UpdateCertificateOptions), arg0)
+}
+
+// UpdateCertificateOptionsWithContext mocks base method
+func (m *MockACMAPI) UpdateCertificateOptionsWithContext(arg0 aws.Context, arg1 *acm.UpdateCertificateOptionsInput, arg2 ...request.Option) (*acm.UpdateCertificateOptionsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateCertificateOptionsWithContext", varargs...)
+	ret0, _ := ret[0].(*acm.UpdateCertificateOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCertificateOptionsWithContext indicates an expected call of UpdateCertificateOptionsWithContext
+func (mr *MockACMAPIMockRecorder) UpdateCertificateOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCertificateOptionsWithContext", reflect.TypeOf((*MockACMAPI)(nil).UpdateCertificateOptionsWithContext), varargs...)
+}
+
+// UpdateCertificateOptionsRequest mocks base method
+func (m *MockACMAPI) UpdateCertificateOptionsRequest(arg0 *acm.UpdateCertificateOptionsInput) (*request.Request, *acm.UpdateCertificateOptionsOutput) {
+	ret := m.ctrl.Call(m, "UpdateCertificateOptionsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*acm.UpdateCertificateOptionsOutput)
+	return ret0, ret1
+}
+
+// UpdateCertificateOptionsRequest indicates an expected call of UpdateCertificateOptionsRequest
+func (mr *MockACMAPIMockRecorder) UpdateCertificateOptionsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCertificateOptionsRequest", reflect.TypeOf((*MockACMAPI)(nil).UpdateCertificateOptionsRequest), arg0)
+}
+
+// WaitUntilCertificateValidated mocks base method
+func (m *MockACMAPI) WaitUntilCertificateValidated(arg0 *acm.DescribeCertificateInput) error {
+	ret := m.ctrl.Call(m, "WaitUntilCertificateValidated", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilCertificateValidated indicates an expected call of WaitUntilCertificateValidated
+func (mr *MockACMAPIMockRecorder) WaitUntilCertificateValidated(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilCertificateValidated", reflect.TypeOf((*MockACMAPI)(nil).WaitUntilCertificateValidated), arg0)
+}
+
+// WaitUntilCertificateValidatedWithContext mocks base method
+func (m *MockACMAPI) WaitUntilCertificateValidatedWithContext(arg0 aws.Context, arg1 *acm.DescribeCertificateInput, arg2 ...request.WaiterOption) error {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WaitUntilCertificateValidatedWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilCertificateValidatedWithContext indicates an expected call of WaitUntilCertificateValidatedWithContext
+func (mr *MockACMAPIMockRecorder) WaitUntilCertificateValidatedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilCertificateValidatedWithContext", reflect.TypeOf((*MockACMAPI)(nil).WaitUntilCertificateValidatedWithContext), varargs...)
 }

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -145,6 +145,8 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 
 				if record.Type == "SRV" && reg.Port != 0 {
 					port = strconv.FormatInt(reg.Port, 10)
+				} else if record.Type == "SRV" && reg.ContainerPort != 0 {
+					port = strconv.FormatInt(reg.ContainerPort, 10)
 				}
 
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\n",

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -128,7 +128,7 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
-		fmt.Fprintln(w, "ENDPOINT\tNAMESPACE\tTYPE\tPORT\tTTL\t")
+		fmt.Fprintln(w, "ID\tENDPOINT\tNAMESPACE\tTYPE\tPORT\tTTL\t")
 
 		for _, reg := range service.ServiceRegistries {
 			srv := sd.GetService(reg.RegistryArn)
@@ -147,7 +147,8 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 					port = strconv.FormatInt(reg.Port, 10)
 				}
 
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n",
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\n",
+					srv.Id,
 					srv.Name+"."+srv.Namespace.Name+" ",
 					ns.String(),
 					record.Type,

--- a/ec2/mock/sdk/ec2iface.go
+++ b/ec2/mock/sdk/ec2iface.go
@@ -1663,6 +1663,50 @@ func (mr *MockEC2APIMockRecorder) CreateEgressOnlyInternetGatewayRequest(arg0 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEgressOnlyInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateEgressOnlyInternetGatewayRequest), arg0)
 }
 
+// CreateFleet mocks base method
+func (m *MockEC2API) CreateFleet(arg0 *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
+	ret := m.ctrl.Call(m, "CreateFleet", arg0)
+	ret0, _ := ret[0].(*ec2.CreateFleetOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateFleet indicates an expected call of CreateFleet
+func (mr *MockEC2APIMockRecorder) CreateFleet(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFleet", reflect.TypeOf((*MockEC2API)(nil).CreateFleet), arg0)
+}
+
+// CreateFleetWithContext mocks base method
+func (m *MockEC2API) CreateFleetWithContext(arg0 aws.Context, arg1 *ec2.CreateFleetInput, arg2 ...request.Option) (*ec2.CreateFleetOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateFleetWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateFleetOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateFleetWithContext indicates an expected call of CreateFleetWithContext
+func (mr *MockEC2APIMockRecorder) CreateFleetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFleetWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateFleetWithContext), varargs...)
+}
+
+// CreateFleetRequest mocks base method
+func (m *MockEC2API) CreateFleetRequest(arg0 *ec2.CreateFleetInput) (*request.Request, *ec2.CreateFleetOutput) {
+	ret := m.ctrl.Call(m, "CreateFleetRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateFleetOutput)
+	return ret0, ret1
+}
+
+// CreateFleetRequest indicates an expected call of CreateFleetRequest
+func (mr *MockEC2APIMockRecorder) CreateFleetRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFleetRequest", reflect.TypeOf((*MockEC2API)(nil).CreateFleetRequest), arg0)
+}
+
 // CreateFlowLogs mocks base method
 func (m *MockEC2API) CreateFlowLogs(arg0 *ec2.CreateFlowLogsInput) (*ec2.CreateFlowLogsOutput, error) {
 	ret := m.ctrl.Call(m, "CreateFlowLogs", arg0)
@@ -3159,6 +3203,50 @@ func (mr *MockEC2APIMockRecorder) DeleteEgressOnlyInternetGatewayRequest(arg0 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEgressOnlyInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteEgressOnlyInternetGatewayRequest), arg0)
 }
 
+// DeleteFleets mocks base method
+func (m *MockEC2API) DeleteFleets(arg0 *ec2.DeleteFleetsInput) (*ec2.DeleteFleetsOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteFleets", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteFleetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteFleets indicates an expected call of DeleteFleets
+func (mr *MockEC2APIMockRecorder) DeleteFleets(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleets", reflect.TypeOf((*MockEC2API)(nil).DeleteFleets), arg0)
+}
+
+// DeleteFleetsWithContext mocks base method
+func (m *MockEC2API) DeleteFleetsWithContext(arg0 aws.Context, arg1 *ec2.DeleteFleetsInput, arg2 ...request.Option) (*ec2.DeleteFleetsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteFleetsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteFleetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteFleetsWithContext indicates an expected call of DeleteFleetsWithContext
+func (mr *MockEC2APIMockRecorder) DeleteFleetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleetsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteFleetsWithContext), varargs...)
+}
+
+// DeleteFleetsRequest mocks base method
+func (m *MockEC2API) DeleteFleetsRequest(arg0 *ec2.DeleteFleetsInput) (*request.Request, *ec2.DeleteFleetsOutput) {
+	ret := m.ctrl.Call(m, "DeleteFleetsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteFleetsOutput)
+	return ret0, ret1
+}
+
+// DeleteFleetsRequest indicates an expected call of DeleteFleetsRequest
+func (mr *MockEC2APIMockRecorder) DeleteFleetsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleetsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteFleetsRequest), arg0)
+}
+
 // DeleteFlowLogs mocks base method
 func (m *MockEC2API) DeleteFlowLogs(arg0 *ec2.DeleteFlowLogsInput) (*ec2.DeleteFlowLogsOutput, error) {
 	ret := m.ctrl.Call(m, "DeleteFlowLogs", arg0)
@@ -4523,6 +4611,50 @@ func (mr *MockEC2APIMockRecorder) DescribeAddressesRequest(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddressesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeAddressesRequest), arg0)
 }
 
+// DescribeAggregateIdFormat mocks base method
+func (m *MockEC2API) DescribeAggregateIdFormat(arg0 *ec2.DescribeAggregateIdFormatInput) (*ec2.DescribeAggregateIdFormatOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeAggregateIdFormat", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeAggregateIdFormatOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAggregateIdFormat indicates an expected call of DescribeAggregateIdFormat
+func (mr *MockEC2APIMockRecorder) DescribeAggregateIdFormat(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAggregateIdFormat", reflect.TypeOf((*MockEC2API)(nil).DescribeAggregateIdFormat), arg0)
+}
+
+// DescribeAggregateIdFormatWithContext mocks base method
+func (m *MockEC2API) DescribeAggregateIdFormatWithContext(arg0 aws.Context, arg1 *ec2.DescribeAggregateIdFormatInput, arg2 ...request.Option) (*ec2.DescribeAggregateIdFormatOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeAggregateIdFormatWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeAggregateIdFormatOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAggregateIdFormatWithContext indicates an expected call of DescribeAggregateIdFormatWithContext
+func (mr *MockEC2APIMockRecorder) DescribeAggregateIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAggregateIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeAggregateIdFormatWithContext), varargs...)
+}
+
+// DescribeAggregateIdFormatRequest mocks base method
+func (m *MockEC2API) DescribeAggregateIdFormatRequest(arg0 *ec2.DescribeAggregateIdFormatInput) (*request.Request, *ec2.DescribeAggregateIdFormatOutput) {
+	ret := m.ctrl.Call(m, "DescribeAggregateIdFormatRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeAggregateIdFormatOutput)
+	return ret0, ret1
+}
+
+// DescribeAggregateIdFormatRequest indicates an expected call of DescribeAggregateIdFormatRequest
+func (mr *MockEC2APIMockRecorder) DescribeAggregateIdFormatRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAggregateIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeAggregateIdFormatRequest), arg0)
+}
+
 // DescribeAvailabilityZones mocks base method
 func (m *MockEC2API) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	ret := m.ctrl.Call(m, "DescribeAvailabilityZones", arg0)
@@ -4917,6 +5049,138 @@ func (m *MockEC2API) DescribeExportTasksRequest(arg0 *ec2.DescribeExportTasksInp
 // DescribeExportTasksRequest indicates an expected call of DescribeExportTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeExportTasksRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeExportTasksRequest), arg0)
+}
+
+// DescribeFleetHistory mocks base method
+func (m *MockEC2API) DescribeFleetHistory(arg0 *ec2.DescribeFleetHistoryInput) (*ec2.DescribeFleetHistoryOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeFleetHistory", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeFleetHistoryOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeFleetHistory indicates an expected call of DescribeFleetHistory
+func (mr *MockEC2APIMockRecorder) DescribeFleetHistory(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetHistory", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetHistory), arg0)
+}
+
+// DescribeFleetHistoryWithContext mocks base method
+func (m *MockEC2API) DescribeFleetHistoryWithContext(arg0 aws.Context, arg1 *ec2.DescribeFleetHistoryInput, arg2 ...request.Option) (*ec2.DescribeFleetHistoryOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeFleetHistoryWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeFleetHistoryOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeFleetHistoryWithContext indicates an expected call of DescribeFleetHistoryWithContext
+func (mr *MockEC2APIMockRecorder) DescribeFleetHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetHistoryWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetHistoryWithContext), varargs...)
+}
+
+// DescribeFleetHistoryRequest mocks base method
+func (m *MockEC2API) DescribeFleetHistoryRequest(arg0 *ec2.DescribeFleetHistoryInput) (*request.Request, *ec2.DescribeFleetHistoryOutput) {
+	ret := m.ctrl.Call(m, "DescribeFleetHistoryRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeFleetHistoryOutput)
+	return ret0, ret1
+}
+
+// DescribeFleetHistoryRequest indicates an expected call of DescribeFleetHistoryRequest
+func (mr *MockEC2APIMockRecorder) DescribeFleetHistoryRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetHistoryRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetHistoryRequest), arg0)
+}
+
+// DescribeFleetInstances mocks base method
+func (m *MockEC2API) DescribeFleetInstances(arg0 *ec2.DescribeFleetInstancesInput) (*ec2.DescribeFleetInstancesOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeFleetInstances", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeFleetInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeFleetInstances indicates an expected call of DescribeFleetInstances
+func (mr *MockEC2APIMockRecorder) DescribeFleetInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetInstances), arg0)
+}
+
+// DescribeFleetInstancesWithContext mocks base method
+func (m *MockEC2API) DescribeFleetInstancesWithContext(arg0 aws.Context, arg1 *ec2.DescribeFleetInstancesInput, arg2 ...request.Option) (*ec2.DescribeFleetInstancesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeFleetInstancesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeFleetInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeFleetInstancesWithContext indicates an expected call of DescribeFleetInstancesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeFleetInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetInstancesWithContext), varargs...)
+}
+
+// DescribeFleetInstancesRequest mocks base method
+func (m *MockEC2API) DescribeFleetInstancesRequest(arg0 *ec2.DescribeFleetInstancesInput) (*request.Request, *ec2.DescribeFleetInstancesOutput) {
+	ret := m.ctrl.Call(m, "DescribeFleetInstancesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeFleetInstancesOutput)
+	return ret0, ret1
+}
+
+// DescribeFleetInstancesRequest indicates an expected call of DescribeFleetInstancesRequest
+func (mr *MockEC2APIMockRecorder) DescribeFleetInstancesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetInstancesRequest), arg0)
+}
+
+// DescribeFleets mocks base method
+func (m *MockEC2API) DescribeFleets(arg0 *ec2.DescribeFleetsInput) (*ec2.DescribeFleetsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeFleets", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeFleetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeFleets indicates an expected call of DescribeFleets
+func (mr *MockEC2APIMockRecorder) DescribeFleets(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleets", reflect.TypeOf((*MockEC2API)(nil).DescribeFleets), arg0)
+}
+
+// DescribeFleetsWithContext mocks base method
+func (m *MockEC2API) DescribeFleetsWithContext(arg0 aws.Context, arg1 *ec2.DescribeFleetsInput, arg2 ...request.Option) (*ec2.DescribeFleetsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeFleetsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeFleetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeFleetsWithContext indicates an expected call of DescribeFleetsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeFleetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetsWithContext), varargs...)
+}
+
+// DescribeFleetsRequest mocks base method
+func (m *MockEC2API) DescribeFleetsRequest(arg0 *ec2.DescribeFleetsInput) (*request.Request, *ec2.DescribeFleetsOutput) {
+	ret := m.ctrl.Call(m, "DescribeFleetsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeFleetsOutput)
+	return ret0, ret1
+}
+
+// DescribeFleetsRequest indicates an expected call of DescribeFleetsRequest
+func (mr *MockEC2APIMockRecorder) DescribeFleetsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetsRequest), arg0)
 }
 
 // DescribeFlowLogs mocks base method
@@ -6280,6 +6544,50 @@ func (m *MockEC2API) DescribePrefixListsRequest(arg0 *ec2.DescribePrefixListsInp
 // DescribePrefixListsRequest indicates an expected call of DescribePrefixListsRequest
 func (mr *MockEC2APIMockRecorder) DescribePrefixListsRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrefixListsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePrefixListsRequest), arg0)
+}
+
+// DescribePrincipalIdFormat mocks base method
+func (m *MockEC2API) DescribePrincipalIdFormat(arg0 *ec2.DescribePrincipalIdFormatInput) (*ec2.DescribePrincipalIdFormatOutput, error) {
+	ret := m.ctrl.Call(m, "DescribePrincipalIdFormat", arg0)
+	ret0, _ := ret[0].(*ec2.DescribePrincipalIdFormatOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribePrincipalIdFormat indicates an expected call of DescribePrincipalIdFormat
+func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormat(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormat", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormat), arg0)
+}
+
+// DescribePrincipalIdFormatWithContext mocks base method
+func (m *MockEC2API) DescribePrincipalIdFormatWithContext(arg0 aws.Context, arg1 *ec2.DescribePrincipalIdFormatInput, arg2 ...request.Option) (*ec2.DescribePrincipalIdFormatOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribePrincipalIdFormatWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribePrincipalIdFormatOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribePrincipalIdFormatWithContext indicates an expected call of DescribePrincipalIdFormatWithContext
+func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormatWithContext), varargs...)
+}
+
+// DescribePrincipalIdFormatRequest mocks base method
+func (m *MockEC2API) DescribePrincipalIdFormatRequest(arg0 *ec2.DescribePrincipalIdFormatInput) (*request.Request, *ec2.DescribePrincipalIdFormatOutput) {
+	ret := m.ctrl.Call(m, "DescribePrincipalIdFormatRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribePrincipalIdFormatOutput)
+	return ret0, ret1
+}
+
+// DescribePrincipalIdFormatRequest indicates an expected call of DescribePrincipalIdFormatRequest
+func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormatRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormatRequest), arg0)
 }
 
 // DescribeRegions mocks base method
@@ -9416,6 +9724,50 @@ func (m *MockEC2API) ImportVolumeRequest(arg0 *ec2.ImportVolumeInput) (*request.
 // ImportVolumeRequest indicates an expected call of ImportVolumeRequest
 func (mr *MockEC2APIMockRecorder) ImportVolumeRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).ImportVolumeRequest), arg0)
+}
+
+// ModifyFleet mocks base method
+func (m *MockEC2API) ModifyFleet(arg0 *ec2.ModifyFleetInput) (*ec2.ModifyFleetOutput, error) {
+	ret := m.ctrl.Call(m, "ModifyFleet", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyFleetOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyFleet indicates an expected call of ModifyFleet
+func (mr *MockEC2APIMockRecorder) ModifyFleet(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFleet", reflect.TypeOf((*MockEC2API)(nil).ModifyFleet), arg0)
+}
+
+// ModifyFleetWithContext mocks base method
+func (m *MockEC2API) ModifyFleetWithContext(arg0 aws.Context, arg1 *ec2.ModifyFleetInput, arg2 ...request.Option) (*ec2.ModifyFleetOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyFleetWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyFleetOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyFleetWithContext indicates an expected call of ModifyFleetWithContext
+func (mr *MockEC2APIMockRecorder) ModifyFleetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFleetWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyFleetWithContext), varargs...)
+}
+
+// ModifyFleetRequest mocks base method
+func (m *MockEC2API) ModifyFleetRequest(arg0 *ec2.ModifyFleetInput) (*request.Request, *ec2.ModifyFleetOutput) {
+	ret := m.ctrl.Call(m, "ModifyFleetRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyFleetOutput)
+	return ret0, ret1
+}
+
+// ModifyFleetRequest indicates an expected call of ModifyFleetRequest
+func (mr *MockEC2APIMockRecorder) ModifyFleetRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFleetRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyFleetRequest), arg0)
 }
 
 // ModifyFpgaImageAttribute mocks base method

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -21,6 +21,13 @@ type CreateServiceInput struct {
 	TaskDefinitionArn string
 }
 
+type ServiceRegistry struct {
+	ContainerName string
+	ContainerPort int64
+	Port          int64
+	RegistryArn   string
+}
+
 type Service struct {
 	Cluster           string
 	Cpu               string
@@ -34,6 +41,7 @@ type Service struct {
 	PendingCount      int64
 	RunningCount      int64
 	SecurityGroupIds  []string
+	ServiceRegistries []ServiceRegistry
 	TargetGroupArn    string
 	TaskDefinitionArn string
 	TaskRole          string
@@ -222,6 +230,18 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 
 		if len(service.LoadBalancers) > 0 {
 			s.TargetGroupArn = aws.StringValue(service.LoadBalancers[0].TargetGroupArn)
+		}
+
+		for _, reg := range service.ServiceRegistries {
+			s.ServiceRegistries = append(
+				s.ServiceRegistries,
+				ServiceRegistry{
+					ContainerName: aws.StringValue(reg.ContainerName),
+					ContainerPort: aws.Int64Value(reg.ContainerPort),
+					Port:          aws.Int64Value(reg.Port),
+					RegistryArn:   aws.StringValue(reg.RegistryArn),
+				},
+			)
 		}
 
 		if len(taskDefinition.ContainerDefinitions) > 0 {

--- a/servicediscovery/main.go
+++ b/servicediscovery/main.go
@@ -1,0 +1,16 @@
+package servicediscovery
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+)
+
+type ServiceDiscovery struct {
+	svc *servicediscovery.ServiceDiscovery
+}
+
+func New(sess *session.Session) ServiceDiscovery {
+	return ServiceDiscovery{
+		svc: servicediscovery.New(sess),
+	}
+}

--- a/servicediscovery/namespace.go
+++ b/servicediscovery/namespace.go
@@ -22,7 +22,7 @@ func (sd *ServiceDiscovery) GetNamespace(namespaceId string) Namespace {
 	)
 
 	if err != nil {
-		console.ErrorExit(err, "Could no describe ServiceDiscovery namespace")
+		console.ErrorExit(err, "Could not describe ServiceDiscovery namespace")
 	}
 
 	namespace = Namespace{

--- a/servicediscovery/namespace.go
+++ b/servicediscovery/namespace.go
@@ -1,0 +1,35 @@
+package servicediscovery
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	awssd "github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/turnerlabs/fargate/console"
+)
+
+type Namespace struct {
+	Id      string
+	Name    string
+	Private bool
+}
+
+func (sd *ServiceDiscovery) GetNamespace(namespaceId string) Namespace {
+	var namespace Namespace
+
+	resp, err := sd.svc.GetNamespace(
+		&awssd.GetNamespaceInput{
+			Id: aws.String(namespaceId),
+		},
+	)
+
+	if err != nil {
+		console.ErrorExit(err, "Could no describe ServiceDiscovery namespace")
+	}
+
+	namespace = Namespace{
+		Id:      namespaceId,
+		Name:    aws.StringValue(resp.Namespace.Name),
+		Private: aws.StringValue(resp.Namespace.Type) == awssd.NamespaceTypeDnsPrivate,
+	}
+
+	return namespace
+}

--- a/servicediscovery/service.go
+++ b/servicediscovery/service.go
@@ -1,0 +1,60 @@
+package servicediscovery
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awssd "github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/turnerlabs/fargate/console"
+)
+
+type DnsRecord struct {
+	TTL  int64
+	Type string
+}
+
+type Service struct {
+	Id         string
+	DnsRecords []DnsRecord
+	Name       string
+	Namespace  Namespace
+}
+
+func (sd *ServiceDiscovery) GetService(registryArn string) Service {
+	var service Service
+
+	arnSlice := strings.Split(registryArn, "/")
+	id := arnSlice[len(arnSlice)-1]
+
+	resp, err := sd.svc.GetService(
+		&awssd.GetServiceInput{
+			Id: aws.String(id),
+		},
+	)
+
+	if err != nil {
+		console.ErrorExit(err, "Could not describe ServiceDiscovery service")
+	}
+
+	namespace := sd.GetNamespace(
+		aws.StringValue(resp.Service.DnsConfig.NamespaceId),
+	)
+
+	service = Service{
+		Id:        id,
+		Name:      aws.StringValue(resp.Service.Name),
+		Namespace: namespace,
+	}
+
+	for _, dnsRecord := range resp.Service.DnsConfig.DnsRecords {
+		service.DnsRecords = append(
+			service.DnsRecords,
+			DnsRecord{
+				TTL:  aws.Int64Value(dnsRecord.TTL),
+				Type: aws.StringValue(dnsRecord.Type),
+			},
+		)
+	}
+
+	return service
+}


### PR DESCRIPTION
Adds ECS service discovery to `fargate service info` cmd. Info will only output if configured on the ECS service.

See:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html
https://medium.com/containers-on-aws/how-to-setup-service-discovery-in-elastic-container-service-3d18479959e6

Example output:
```
Service Name: search-graphql
Status:
  Desired: 1
  Running: 1
  Pending: 0
Image: quay.io/turner/turner-defaultbackend:0.2.0
Cpu: 256
Memory: 512
Task Role: arn:aws:iam::981181454727:role/search-graphql-test
Subnets: subnet-2bdd0506, subnet-30cc4779, subnet-4b1dc110, subnet-587ab964
Security Groups: sg-0f96a1d2d836ef8cc

Service Discovery
ID			ENDPOINT			NAMESPACE		TYPE	PORT	TTL
srv-27lqdbganrrirgkz	search-graphql-test.internal 	internal (PRIVATE)	A		10
srv-27lqdbganrrirgkz	search-graphql-test.internal 	internal (PRIVATE)	SRV	3000	10

Tasks
ID					IMAGE						STATUS	RUNNING	IP	CPU	MEMORY	DEPLOYMENT
ee7b9654-46d6-46e0-8523-4937dea2631c	quay.io/turner/turner-defaultbackend:0.2.0	running	2h15m5s		256	512	2

Deployments
ID	IMAGE						STATUS	CREATED				DESIRED	RUNNING	PENDING
2	quay.io/turner/turner-defaultbackend:0.2.0	primary	2018-08-20 19:13:42 +0000 UTC	1	1	0

Events
[2018-08-20 19:14:39 +0000 UTC] (service search-graphql) has reached a steady state.
[2018-08-20 19:13:49 +0000 UTC] (service search-graphql) has started 1 tasks: (task ee7b9654-46d6-46e0-8523-4937dea2631c).
```

Also, had to bump the AWS SDK version for access to the ServiceRegistries field on ecs.Service (added in [v1.13.54](https://github.com/aws/aws-sdk-go/blob/master/CHANGELOG.md#release-v11354-2018-05-22))