### PR TITLE
implements task register command (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Console, or until they are interrupted for any reason.
 fargate task register [--image <docker-image>] [-e KEY=value -e KEY2=value] [--env-file dev.env]
 ```
 
-Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for the specified docker image or environment variables based on the latest revision of the task family and returns the new ARN.
+Registers a new [task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for the specified docker image or environment variables based on the latest revision of the task family and returns the new revision number.
 
 The Docker container image to use in the new Task Definition can be specified
 via the --image flag.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ There are several ways to specify parameters.  Each item takes precedence over t
 ```yaml
 cluster: my-cluster
 service: my-service
+task: my-task
 verbose: false
 nocolor: true
 ```
@@ -75,6 +76,7 @@ nocolor: true
 ### Commands
 
 - [Services](#services)
+- [Tasks](#tasks)
 
 #### Services
 
@@ -128,7 +130,9 @@ fargate service deploy [--file docker-compose.yml]
 
 Deploy image and environment variables defined in a [docker compose file](https://docs.docker.com/compose/overview/) to service
 
-Deploy a docker [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file together as a single unit. This allows you to run `docker-compose up` locally to run your app the same way it will run in AWS. Note that while the docker-compose yaml configuration supports numerous options, only the image and environment variables are deployed to fargate. If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy. For example:
+Deploy a docker [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file together as a single unit. Note that environments variables are replaced with what's in the compose file.
+
+This allows you to run `docker-compose up` locally to run your app the same way it will run in AWS. Note that while the docker-compose yaml configuration supports numerous options, only the image and environment variables are deployed to fargate. If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy. For example:
 
 ```yaml
 version: '3'
@@ -295,6 +299,43 @@ Restart service
 Creates a new set of tasks for the service and stops the previous tasks. This
 is useful if your service needs to reload data cached from an external source,
 for example.
+
+
+#### Tasks
+
+##### Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| --task | -t | | Task Definition Family |
+
+Tasks are one-time executions of your container. Instances of your task are run
+until you manually stop them either through AWS APIs, the AWS Management
+Console, or until they are interrupted for any reason.
+
+- [register](#fargate-task-register)
+
+
+##### fargate task register
+
+```console
+fargate task register [--image <docker-image>] [-e KEY=value -e KEY2=value] [--env-file dev.env]
+```
+
+Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for the specified docker image or environment variables based on the latest revision of the task family and returns the new ARN.
+
+The Docker container image to use in the new Task Definition can be specified
+via the --image flag.
+
+
+```console
+fargate task register [--file docker-compose.yml]
+```
+
+Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) using the [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file. Note that environments variables are replaced with what's in the compose file.
+
+If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy.
+
 
 
 [region-table]: https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,12 +13,13 @@ const (
 	keyService = "service"
 	keyVerbose = "verbose"
 	keyNoColor = "nocolor"
+	keyTask    = "task"
 )
 
 //configure viper to manage parameter input
 func initConfig(cmd *cobra.Command) {
 
-	//config file
+	//config file (fargate.yml)
 	viper.SetConfigName("fargate")
 	viper.AddConfigPath("./")
 	viper.ReadInConfig()
@@ -28,6 +29,7 @@ func initConfig(cmd *cobra.Command) {
 	viper.BindEnv(keyService, "FARGATE_SERVICE")
 	viper.BindEnv(keyVerbose, "FARGATE_VERBOSE")
 	viper.BindEnv(keyNoColor, "FARGATE_NOCOLOR")
+	viper.BindEnv(keyTask, "FARGATE_TASK")
 
 	//cli arg
 	initPFlag(keyCluster, cmd)
@@ -54,6 +56,16 @@ func getServiceName() string {
 	result := viper.GetString(keyService)
 	if result == "" {
 		fmt.Println("please specify service using: fargate.yml, FARGATE_SERVICE envvar, or --service")
+		os.Exit(-1)
+	}
+	return result
+}
+
+//task can come from fargate.yml, FARGATE_TASK, or --task cli arg
+func getTaskName() string {
+	result := viper.GetString(keyTask)
+	if result == "" {
+		fmt.Println("please specify task family using: fargate.yml, FARGATE_TASK envvar, or --task")
 		os.Exit(-1)
 	}
 	return result

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"regexp"
@@ -158,6 +159,7 @@ func init() {
 	initConfig(rootCmd)
 }
 
+//converts array of KEY=VALUE to array of EnvVar types
 func extractEnvVars(inputEnvVars []string) []ECS.EnvVar {
 	var envVars []ECS.EnvVar
 
@@ -192,6 +194,21 @@ func extractEnvVars(inputEnvVars []string) []ECS.EnvVar {
 	}
 
 	return envVars
+}
+
+func convertEnvVarKeyValuesToECSEnvVars(inputEnvVars []string, envVarFile string) []ECS.EnvVar {
+	if envVarFile != "" {
+		file, err := os.Open(envVarFile)
+		if err != nil {
+			console.IssueExit("ERROR: unable to read env var file:", err)
+		}
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			inputEnvVars = append(inputEnvVars, scanner.Text())
+		}
+	}
+	return extractEnvVars(inputEnvVars)
 }
 
 func validateCpuAndMemory(inputCpuUnits, inputMebibytes string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"regexp"
@@ -194,21 +193,6 @@ func extractEnvVars(inputEnvVars []string) []ECS.EnvVar {
 	}
 
 	return envVars
-}
-
-func convertEnvVarKeyValuesToECSEnvVars(inputEnvVars []string, envVarFile string) []ECS.EnvVar {
-	if envVarFile != "" {
-		file, err := os.Open(envVarFile)
-		if err != nil {
-			console.IssueExit("ERROR: unable to read env var file:", err)
-		}
-		defer file.Close()
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			inputEnvVars = append(inputEnvVars, scanner.Text())
-		}
-	}
-	return extractEnvVars(inputEnvVars)
 }
 
 func validateCpuAndMemory(inputCpuUnits, inputMebibytes string) error {

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -85,7 +85,7 @@ func deployDockerComposeFile(operation *ServiceDeployOperation) {
 	if flagServiceDeployDockerComposeImageOnly {
 		//register a new task definition based on the image from the compose file
 		taskDefinitionArn = ecs.UpdateTaskDefinitionImage(ecsService.TaskDefinitionArn, dockerService.Image)
-		
+
 	} else {
 		//register a new task definition based on the image and environment variables from the compose file
 		taskDefinitionArn = ecs.UpdateTaskDefinitionImageAndEnvVars(ecsService.TaskDefinitionArn, dockerService.Image, envvars, true)
@@ -94,7 +94,7 @@ func deployDockerComposeFile(operation *ServiceDeployOperation) {
 	//update service with new task definition
 	ecs.UpdateServiceTaskDefinition(operation.ServiceName, taskDefinitionArn)
 
-	console.Info("Deployed %s to service %s as deployment %s", operation.ComposeFile, operation.ServiceName, ecs.GetDeploymentId(taskDefinitionArn))
+	console.Info("Deployed %s to service %s as revision %s", operation.ComposeFile, operation.ServiceName, ecs.GetRevisionNumber(taskDefinitionArn))
 }
 
 func getDockerServiceFromComposeFile(dockerComposeFile string) *dockercompose.Service {

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -75,8 +75,31 @@ func deployService(operation *ServiceDeployOperation) {
 func deployDockerComposeFile(operation *ServiceDeployOperation) {
 	var taskDefinitionArn string
 
+	ecs := ECS.New(sess, getClusterName())
+	ecsService := ecs.DescribeService(operation.ServiceName)
+
+	dockerService := getDockerServiceFromComposeFile(operation.ComposeFile)
+	envvars := convertDockerComposeEnvVarsToECSEnvVars(dockerService)
+
+	//if --image-only flag is set, update image only
+	if flagServiceDeployDockerComposeImageOnly {
+		//register a new task definition based on the image from the compose file
+		taskDefinitionArn = ecs.UpdateTaskDefinitionImage(ecsService.TaskDefinitionArn, dockerService.Image)
+		
+	} else {
+		//register a new task definition based on the image and environment variables from the compose file
+		taskDefinitionArn = ecs.UpdateTaskDefinitionImageAndEnvVars(ecsService.TaskDefinitionArn, dockerService.Image, envvars, true)
+	}
+
+	//update service with new task definition
+	ecs.UpdateServiceTaskDefinition(operation.ServiceName, taskDefinitionArn)
+
+	console.Info("Deployed %s to service %s as deployment %s", operation.ComposeFile, operation.ServiceName, ecs.GetDeploymentId(taskDefinitionArn))
+}
+
+func getDockerServiceFromComposeFile(dockerComposeFile string) *dockercompose.Service {
 	//read the compose file configuration
-	composeFile := dockercompose.NewComposeFile(operation.ComposeFile)
+	composeFile := dockercompose.NewComposeFile(dockerComposeFile)
 	dockerCompose := composeFile.Config()
 
 	//determine which docker-compose service/container to deploy
@@ -85,22 +108,18 @@ func deployDockerComposeFile(operation *ServiceDeployOperation) {
 		console.IssueExit(`Please indicate which docker container you'd like to deploy using the label "%s: 1"`, deployDockerComposeLabel)
 	}
 
-	ecs := ECS.New(sess, getClusterName())
-	ecsService := ecs.DescribeService(operation.ServiceName)
+	return dockerService
+}
 
-	//only update image if --image-only flag is set
-	if flagServiceDeployDockerComposeImageOnly {
-		//register a new task definition based on the image from the compose file
-		taskDefinitionArn = ecs.UpdateTaskDefinitionImage(ecsService.TaskDefinitionArn, dockerService.Image)
-	} else {
-		//register a new task definition based on the image and environment variables from the compose file
-		taskDefinitionArn = ecs.UpdateTaskDefinitionImageAndEnvVars(ecsService.TaskDefinitionArn, dockerService.Image, dockerService.Environment)
+func convertDockerComposeEnvVarsToECSEnvVars(service *dockercompose.Service) []ECS.EnvVar {
+	result := []ECS.EnvVar{}
+	for k, v := range service.Environment {
+		result = append(result, ECS.EnvVar{
+			Key:   k,
+			Value: v,
+		})
 	}
-
-	//update service with new task definition
-	ecs.UpdateServiceTaskDefinition(operation.ServiceName, taskDefinitionArn)
-
-	console.Info("Deployed %s to service %s as deployment %s", operation.ComposeFile, operation.ServiceName, ecs.GetDeploymentId(taskDefinitionArn))
+	return result
 }
 
 //determine which docker-compose service/container to deploy

--- a/cmd/service_env_set.go
+++ b/cmd/service_env_set.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"bufio"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/turnerlabs/fargate/console"
 	ECS "github.com/turnerlabs/fargate/ecs"
-	"os"
 )
 
 type ServiceEnvSetOperation struct {
@@ -20,10 +21,14 @@ func (o *ServiceEnvSetOperation) Validate() {
 }
 
 func (o *ServiceEnvSetOperation) SetEnvVars(inputEnvVars []string, envVarFile string) {
+	o.EnvVars = processEnvVarArgs(inputEnvVars, envVarFile)
+}
+
+func processEnvVarArgs(inputEnvVars []string, envVarFile string) []ECS.EnvVar {
 	if envVarFile != "" {
 		file, err := os.Open(envVarFile)
 		if err != nil {
-			return
+			return []ECS.EnvVar{}
 		}
 		defer file.Close()
 		scanner := bufio.NewScanner(file)
@@ -31,7 +36,7 @@ func (o *ServiceEnvSetOperation) SetEnvVars(inputEnvVars []string, envVarFile st
 			inputEnvVars = append(inputEnvVars, scanner.Text())
 		}
 	}
-	o.EnvVars = extractEnvVars(inputEnvVars)
+	return extractEnvVars(inputEnvVars)
 }
 
 var flagServiceEnvSetEnvVars []string

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// const taskLogGroupFormat = "/fargate/task/%s"
+
+var taskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "Manage tasks",
+	Long: `Manage tasks
+Tasks are one-time executions of your container. Instances of your task are run
+until you manually stop them either through AWS APIs, the AWS Management
+Console, or until they are interrupted for any reason.`,
+}
+
+var taskName string
+
+func init() {
+	rootCmd.AddCommand(taskCmd)
+	taskCmd.PersistentFlags().StringVarP(&taskName, "task", "t", "", `ECS task family name`)
+	initPFlag(keyTask, taskCmd)
+}

--- a/cmd/task_register.go
+++ b/cmd/task_register.go
@@ -24,7 +24,7 @@ type taskRegisterOperation struct {
 
 var taskRegisterCmd = &cobra.Command{
 	Use:   "register",
-	Short: "Registers a new Task Definition for the specified docker image or environment variables based on the latest revision of the task family and returns the new ARN.",
+	Short: "Registers a new task definition revision for the specified docker image or environment variables based on the latest revision of the task family and returns the new revision number.",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		operation := taskRegisterOperation{
@@ -89,8 +89,8 @@ func registerTask(op taskRegisterOperation) {
 
 	//update and register new task definition
 	ecs := ECS.New(sess, op.Cluster)
-	result := ecs.UpdateTaskDefinitionImageAndEnvVars(op.Task, image, envvars, replaceEnvVars)
+	newTD := ecs.UpdateTaskDefinitionImageAndEnvVars(op.Task, image, envvars, replaceEnvVars)
 
-	//output new arn
-	fmt.Println(result)
+	//output new revision
+	fmt.Println(ecs.GetRevisionNumber(newTD))
 }

--- a/cmd/task_register.go
+++ b/cmd/task_register.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	ECS "github.com/turnerlabs/fargate/ecs"
+)
+
+var flagTaskRegisterImage string
+var flagTaskRegisterDockerComposeFile string
+var flagTaskRegisterEnvVars []string
+var flagTaskRegisterEnvFile string
+
+//represents a task register operation
+type taskRegisterOperation struct {
+	Cluster     string
+	Task        string
+	Image       string
+	EnvVars     []string
+	EnvFile     string
+	ComposeFile string
+}
+
+var taskRegisterCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Registers a new Task Definition for the specified docker image or environment variables based on the latest revision of the task family and returns the new ARN.",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		operation := taskRegisterOperation{
+			Cluster:     getClusterName(),
+			Task:        getTaskName(),
+			Image:       flagTaskRegisterImage,
+			EnvVars:     flagTaskRegisterEnvVars,
+			EnvFile:     flagTaskRegisterEnvFile,
+			ComposeFile: flagTaskRegisterDockerComposeFile,
+		}
+
+		//valid cli arg combinations
+		nonComposeOptions := (flagTaskRegisterImage != "" || len(flagTaskRegisterEnvVars) > 0 || flagTaskRegisterEnvFile != "")
+		if (flagTaskRegisterDockerComposeFile != "" && nonComposeOptions) ||
+			(flagTaskRegisterDockerComposeFile == "" && !nonComposeOptions) {
+			cmd.Help()
+			return
+		}
+
+		registerTask(operation)
+	},
+	Example: `
+fargate task register --image 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app:0.1.0
+fargate task register --image 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app:0.1.0 --env FOO=bar --env BAR=baz
+fargate task register --env-file dev.env
+fargate task register --file docker-compose.yml
+`,
+}
+
+func init() {
+	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterImage, "image", "i", "", "Docker image to register")
+
+	taskRegisterCmd.Flags().StringArrayVarP(&flagTaskRegisterEnvVars, "env", "e", []string{}, "Environment variables to set [e.g. -e KEY=value -e KEY2=value]")
+
+	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterEnvFile, "env-file", "", "", "File containing list of environment variables to set, one per line, of the form KEY=value")
+
+	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterDockerComposeFile, "file", "f", "", "Docker Compose file containing image and environment variables to register.")
+
+	taskCmd.AddCommand(taskRegisterCmd)
+}
+
+func registerTask(op taskRegisterOperation) {
+
+	//are we registering from cli args or a compose file?
+	image := op.Image
+	var envvars []ECS.EnvVar
+	replaceEnvVars := false
+
+	if op.ComposeFile != "" {
+		dockerService := getDockerServiceFromComposeFile(op.ComposeFile)
+		image = dockerService.Image
+		envvars = convertDockerComposeEnvVarsToECSEnvVars(dockerService)
+		replaceEnvVars = true
+
+	} else {
+		//read env file (if specified) and combine with other envvars
+		envvars = processEnvVarArgs(op.EnvVars, op.EnvFile)
+
+		//don't replace, just add, update where exists
+		replaceEnvVars = false
+	}
+
+	//update and register new task definition
+	ecs := ECS.New(sess, op.Cluster)
+	result := ecs.UpdateTaskDefinitionImageAndEnvVars(op.Task, image, envvars, replaceEnvVars)
+
+	//output new arn
+	fmt.Println(result)
+}

--- a/ec2/mock/sdk/ec2iface.go
+++ b/ec2/mock/sdk/ec2iface.go
@@ -167,6 +167,50 @@ func (mr *MockEC2APIMockRecorder) AcceptVpcPeeringConnectionRequest(arg0 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcPeeringConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcPeeringConnectionRequest), arg0)
 }
 
+// AdvertiseByoipCidr mocks base method
+func (m *MockEC2API) AdvertiseByoipCidr(arg0 *ec2.AdvertiseByoipCidrInput) (*ec2.AdvertiseByoipCidrOutput, error) {
+	ret := m.ctrl.Call(m, "AdvertiseByoipCidr", arg0)
+	ret0, _ := ret[0].(*ec2.AdvertiseByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdvertiseByoipCidr indicates an expected call of AdvertiseByoipCidr
+func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidr(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidr", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidr), arg0)
+}
+
+// AdvertiseByoipCidrWithContext mocks base method
+func (m *MockEC2API) AdvertiseByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.AdvertiseByoipCidrInput, arg2 ...request.Option) (*ec2.AdvertiseByoipCidrOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdvertiseByoipCidrWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AdvertiseByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdvertiseByoipCidrWithContext indicates an expected call of AdvertiseByoipCidrWithContext
+func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidrWithContext), varargs...)
+}
+
+// AdvertiseByoipCidrRequest mocks base method
+func (m *MockEC2API) AdvertiseByoipCidrRequest(arg0 *ec2.AdvertiseByoipCidrInput) (*request.Request, *ec2.AdvertiseByoipCidrOutput) {
+	ret := m.ctrl.Call(m, "AdvertiseByoipCidrRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AdvertiseByoipCidrOutput)
+	return ret0, ret1
+}
+
+// AdvertiseByoipCidrRequest indicates an expected call of AdvertiseByoipCidrRequest
+func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidrRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidrRequest), arg0)
+}
+
 // AllocateAddress mocks base method
 func (m *MockEC2API) AllocateAddress(arg0 *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
 	ret := m.ctrl.Call(m, "AllocateAddress", arg0)
@@ -1003,6 +1047,50 @@ func (mr *MockEC2APIMockRecorder) CancelBundleTaskRequest(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelBundleTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CancelBundleTaskRequest), arg0)
 }
 
+// CancelCapacityReservation mocks base method
+func (m *MockEC2API) CancelCapacityReservation(arg0 *ec2.CancelCapacityReservationInput) (*ec2.CancelCapacityReservationOutput, error) {
+	ret := m.ctrl.Call(m, "CancelCapacityReservation", arg0)
+	ret0, _ := ret[0].(*ec2.CancelCapacityReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CancelCapacityReservation indicates an expected call of CancelCapacityReservation
+func (mr *MockEC2APIMockRecorder) CancelCapacityReservation(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservation), arg0)
+}
+
+// CancelCapacityReservationWithContext mocks base method
+func (m *MockEC2API) CancelCapacityReservationWithContext(arg0 aws.Context, arg1 *ec2.CancelCapacityReservationInput, arg2 ...request.Option) (*ec2.CancelCapacityReservationOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CancelCapacityReservationWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CancelCapacityReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CancelCapacityReservationWithContext indicates an expected call of CancelCapacityReservationWithContext
+func (mr *MockEC2APIMockRecorder) CancelCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservationWithContext), varargs...)
+}
+
+// CancelCapacityReservationRequest mocks base method
+func (m *MockEC2API) CancelCapacityReservationRequest(arg0 *ec2.CancelCapacityReservationInput) (*request.Request, *ec2.CancelCapacityReservationOutput) {
+	ret := m.ctrl.Call(m, "CancelCapacityReservationRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelCapacityReservationOutput)
+	return ret0, ret1
+}
+
+// CancelCapacityReservationRequest indicates an expected call of CancelCapacityReservationRequest
+func (mr *MockEC2APIMockRecorder) CancelCapacityReservationRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservationRequest), arg0)
+}
+
 // CancelConversionTask mocks base method
 func (m *MockEC2API) CancelConversionTask(arg0 *ec2.CancelConversionTaskInput) (*ec2.CancelConversionTaskOutput, error) {
 	ret := m.ctrl.Call(m, "CancelConversionTask", arg0)
@@ -1441,6 +1529,50 @@ func (m *MockEC2API) CopySnapshotRequest(arg0 *ec2.CopySnapshotInput) (*request.
 // CopySnapshotRequest indicates an expected call of CopySnapshotRequest
 func (mr *MockEC2APIMockRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySnapshotRequest", reflect.TypeOf((*MockEC2API)(nil).CopySnapshotRequest), arg0)
+}
+
+// CreateCapacityReservation mocks base method
+func (m *MockEC2API) CreateCapacityReservation(arg0 *ec2.CreateCapacityReservationInput) (*ec2.CreateCapacityReservationOutput, error) {
+	ret := m.ctrl.Call(m, "CreateCapacityReservation", arg0)
+	ret0, _ := ret[0].(*ec2.CreateCapacityReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCapacityReservation indicates an expected call of CreateCapacityReservation
+func (mr *MockEC2APIMockRecorder) CreateCapacityReservation(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservation), arg0)
+}
+
+// CreateCapacityReservationWithContext mocks base method
+func (m *MockEC2API) CreateCapacityReservationWithContext(arg0 aws.Context, arg1 *ec2.CreateCapacityReservationInput, arg2 ...request.Option) (*ec2.CreateCapacityReservationOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateCapacityReservationWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateCapacityReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCapacityReservationWithContext indicates an expected call of CreateCapacityReservationWithContext
+func (mr *MockEC2APIMockRecorder) CreateCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationWithContext), varargs...)
+}
+
+// CreateCapacityReservationRequest mocks base method
+func (m *MockEC2API) CreateCapacityReservationRequest(arg0 *ec2.CreateCapacityReservationInput) (*request.Request, *ec2.CreateCapacityReservationOutput) {
+	ret := m.ctrl.Call(m, "CreateCapacityReservationRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateCapacityReservationOutput)
+	return ret0, ret1
+}
+
+// CreateCapacityReservationRequest indicates an expected call of CreateCapacityReservationRequest
+func (mr *MockEC2APIMockRecorder) CreateCapacityReservationRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationRequest), arg0)
 }
 
 // CreateCustomerGateway mocks base method
@@ -4479,6 +4611,50 @@ func (mr *MockEC2APIMockRecorder) DeleteVpnGatewayRequest(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnGatewayRequest), arg0)
 }
 
+// DeprovisionByoipCidr mocks base method
+func (m *MockEC2API) DeprovisionByoipCidr(arg0 *ec2.DeprovisionByoipCidrInput) (*ec2.DeprovisionByoipCidrOutput, error) {
+	ret := m.ctrl.Call(m, "DeprovisionByoipCidr", arg0)
+	ret0, _ := ret[0].(*ec2.DeprovisionByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeprovisionByoipCidr indicates an expected call of DeprovisionByoipCidr
+func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidr(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidr", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidr), arg0)
+}
+
+// DeprovisionByoipCidrWithContext mocks base method
+func (m *MockEC2API) DeprovisionByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.DeprovisionByoipCidrInput, arg2 ...request.Option) (*ec2.DeprovisionByoipCidrOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeprovisionByoipCidrWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeprovisionByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeprovisionByoipCidrWithContext indicates an expected call of DeprovisionByoipCidrWithContext
+func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidrWithContext), varargs...)
+}
+
+// DeprovisionByoipCidrRequest mocks base method
+func (m *MockEC2API) DeprovisionByoipCidrRequest(arg0 *ec2.DeprovisionByoipCidrInput) (*request.Request, *ec2.DeprovisionByoipCidrOutput) {
+	ret := m.ctrl.Call(m, "DeprovisionByoipCidrRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeprovisionByoipCidrOutput)
+	return ret0, ret1
+}
+
+// DeprovisionByoipCidrRequest indicates an expected call of DeprovisionByoipCidrRequest
+func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidrRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidrRequest), arg0)
+}
+
 // DeregisterImage mocks base method
 func (m *MockEC2API) DeregisterImage(arg0 *ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
 	ret := m.ctrl.Call(m, "DeregisterImage", arg0)
@@ -4741,6 +4917,94 @@ func (m *MockEC2API) DescribeBundleTasksRequest(arg0 *ec2.DescribeBundleTasksInp
 // DescribeBundleTasksRequest indicates an expected call of DescribeBundleTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeBundleTasksRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeBundleTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeBundleTasksRequest), arg0)
+}
+
+// DescribeByoipCidrs mocks base method
+func (m *MockEC2API) DescribeByoipCidrs(arg0 *ec2.DescribeByoipCidrsInput) (*ec2.DescribeByoipCidrsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeByoipCidrs", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeByoipCidrsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeByoipCidrs indicates an expected call of DescribeByoipCidrs
+func (mr *MockEC2APIMockRecorder) DescribeByoipCidrs(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrs", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrs), arg0)
+}
+
+// DescribeByoipCidrsWithContext mocks base method
+func (m *MockEC2API) DescribeByoipCidrsWithContext(arg0 aws.Context, arg1 *ec2.DescribeByoipCidrsInput, arg2 ...request.Option) (*ec2.DescribeByoipCidrsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeByoipCidrsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeByoipCidrsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeByoipCidrsWithContext indicates an expected call of DescribeByoipCidrsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeByoipCidrsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrsWithContext), varargs...)
+}
+
+// DescribeByoipCidrsRequest mocks base method
+func (m *MockEC2API) DescribeByoipCidrsRequest(arg0 *ec2.DescribeByoipCidrsInput) (*request.Request, *ec2.DescribeByoipCidrsOutput) {
+	ret := m.ctrl.Call(m, "DescribeByoipCidrsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeByoipCidrsOutput)
+	return ret0, ret1
+}
+
+// DescribeByoipCidrsRequest indicates an expected call of DescribeByoipCidrsRequest
+func (mr *MockEC2APIMockRecorder) DescribeByoipCidrsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrsRequest), arg0)
+}
+
+// DescribeCapacityReservations mocks base method
+func (m *MockEC2API) DescribeCapacityReservations(arg0 *ec2.DescribeCapacityReservationsInput) (*ec2.DescribeCapacityReservationsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeCapacityReservations", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeCapacityReservationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeCapacityReservations indicates an expected call of DescribeCapacityReservations
+func (mr *MockEC2APIMockRecorder) DescribeCapacityReservations(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservations", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservations), arg0)
+}
+
+// DescribeCapacityReservationsWithContext mocks base method
+func (m *MockEC2API) DescribeCapacityReservationsWithContext(arg0 aws.Context, arg1 *ec2.DescribeCapacityReservationsInput, arg2 ...request.Option) (*ec2.DescribeCapacityReservationsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeCapacityReservationsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeCapacityReservationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeCapacityReservationsWithContext indicates an expected call of DescribeCapacityReservationsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeCapacityReservationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservationsWithContext), varargs...)
+}
+
+// DescribeCapacityReservationsRequest mocks base method
+func (m *MockEC2API) DescribeCapacityReservationsRequest(arg0 *ec2.DescribeCapacityReservationsInput) (*request.Request, *ec2.DescribeCapacityReservationsOutput) {
+	ret := m.ctrl.Call(m, "DescribeCapacityReservationsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeCapacityReservationsOutput)
+	return ret0, ret1
+}
+
+// DescribeCapacityReservationsRequest indicates an expected call of DescribeCapacityReservationsRequest
+func (mr *MockEC2APIMockRecorder) DescribeCapacityReservationsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservationsRequest), arg0)
 }
 
 // DescribeClassicLinkInstances mocks base method
@@ -6458,6 +6722,35 @@ func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesRequest(arg0 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesRequest), arg0)
 }
 
+// DescribeNetworkInterfacesPages mocks base method
+func (m *MockEC2API) DescribeNetworkInterfacesPages(arg0 *ec2.DescribeNetworkInterfacesInput, arg1 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInterfacesPages indicates an expected call of DescribeNetworkInterfacesPages
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesPages(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesPages), arg0, arg1)
+}
+
+// DescribeNetworkInterfacesPagesWithContext mocks base method
+func (m *MockEC2API) DescribeNetworkInterfacesPagesWithContext(arg0 aws.Context, arg1 *ec2.DescribeNetworkInterfacesInput, arg2 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool, arg3 ...request.Option) error {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInterfacesPagesWithContext indicates an expected call of DescribeNetworkInterfacesPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesPagesWithContext), varargs...)
+}
+
 // DescribePlacementGroups mocks base method
 func (m *MockEC2API) DescribePlacementGroups(arg0 *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
 	ret := m.ctrl.Call(m, "DescribePlacementGroups", arg0)
@@ -6588,6 +6881,50 @@ func (m *MockEC2API) DescribePrincipalIdFormatRequest(arg0 *ec2.DescribePrincipa
 // DescribePrincipalIdFormatRequest indicates an expected call of DescribePrincipalIdFormatRequest
 func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormatRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormatRequest), arg0)
+}
+
+// DescribePublicIpv4Pools mocks base method
+func (m *MockEC2API) DescribePublicIpv4Pools(arg0 *ec2.DescribePublicIpv4PoolsInput) (*ec2.DescribePublicIpv4PoolsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribePublicIpv4Pools", arg0)
+	ret0, _ := ret[0].(*ec2.DescribePublicIpv4PoolsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribePublicIpv4Pools indicates an expected call of DescribePublicIpv4Pools
+func (mr *MockEC2APIMockRecorder) DescribePublicIpv4Pools(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4Pools", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4Pools), arg0)
+}
+
+// DescribePublicIpv4PoolsWithContext mocks base method
+func (m *MockEC2API) DescribePublicIpv4PoolsWithContext(arg0 aws.Context, arg1 *ec2.DescribePublicIpv4PoolsInput, arg2 ...request.Option) (*ec2.DescribePublicIpv4PoolsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribePublicIpv4PoolsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribePublicIpv4PoolsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribePublicIpv4PoolsWithContext indicates an expected call of DescribePublicIpv4PoolsWithContext
+func (mr *MockEC2APIMockRecorder) DescribePublicIpv4PoolsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4PoolsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4PoolsWithContext), varargs...)
+}
+
+// DescribePublicIpv4PoolsRequest mocks base method
+func (m *MockEC2API) DescribePublicIpv4PoolsRequest(arg0 *ec2.DescribePublicIpv4PoolsInput) (*request.Request, *ec2.DescribePublicIpv4PoolsOutput) {
+	ret := m.ctrl.Call(m, "DescribePublicIpv4PoolsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribePublicIpv4PoolsOutput)
+	return ret0, ret1
+}
+
+// DescribePublicIpv4PoolsRequest indicates an expected call of DescribePublicIpv4PoolsRequest
+func (mr *MockEC2APIMockRecorder) DescribePublicIpv4PoolsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4PoolsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4PoolsRequest), arg0)
 }
 
 // DescribeRegions mocks base method
@@ -9726,6 +10063,50 @@ func (mr *MockEC2APIMockRecorder) ImportVolumeRequest(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).ImportVolumeRequest), arg0)
 }
 
+// ModifyCapacityReservation mocks base method
+func (m *MockEC2API) ModifyCapacityReservation(arg0 *ec2.ModifyCapacityReservationInput) (*ec2.ModifyCapacityReservationOutput, error) {
+	ret := m.ctrl.Call(m, "ModifyCapacityReservation", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyCapacityReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyCapacityReservation indicates an expected call of ModifyCapacityReservation
+func (mr *MockEC2APIMockRecorder) ModifyCapacityReservation(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservation), arg0)
+}
+
+// ModifyCapacityReservationWithContext mocks base method
+func (m *MockEC2API) ModifyCapacityReservationWithContext(arg0 aws.Context, arg1 *ec2.ModifyCapacityReservationInput, arg2 ...request.Option) (*ec2.ModifyCapacityReservationOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyCapacityReservationWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyCapacityReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyCapacityReservationWithContext indicates an expected call of ModifyCapacityReservationWithContext
+func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationWithContext), varargs...)
+}
+
+// ModifyCapacityReservationRequest mocks base method
+func (m *MockEC2API) ModifyCapacityReservationRequest(arg0 *ec2.ModifyCapacityReservationInput) (*request.Request, *ec2.ModifyCapacityReservationOutput) {
+	ret := m.ctrl.Call(m, "ModifyCapacityReservationRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyCapacityReservationOutput)
+	return ret0, ret1
+}
+
+// ModifyCapacityReservationRequest indicates an expected call of ModifyCapacityReservationRequest
+func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationRequest), arg0)
+}
+
 // ModifyFleet mocks base method
 func (m *MockEC2API) ModifyFleet(arg0 *ec2.ModifyFleetInput) (*ec2.ModifyFleetOutput, error) {
 	ret := m.ctrl.Call(m, "ModifyFleet", arg0)
@@ -10032,6 +10413,50 @@ func (m *MockEC2API) ModifyInstanceAttributeRequest(arg0 *ec2.ModifyInstanceAttr
 // ModifyInstanceAttributeRequest indicates an expected call of ModifyInstanceAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceAttributeRequest), arg0)
+}
+
+// ModifyInstanceCapacityReservationAttributes mocks base method
+func (m *MockEC2API) ModifyInstanceCapacityReservationAttributes(arg0 *ec2.ModifyInstanceCapacityReservationAttributesInput) (*ec2.ModifyInstanceCapacityReservationAttributesOutput, error) {
+	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributes", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyInstanceCapacityReservationAttributes indicates an expected call of ModifyInstanceCapacityReservationAttributes
+func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributes(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributes", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributes), arg0)
+}
+
+// ModifyInstanceCapacityReservationAttributesWithContext mocks base method
+func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesWithContext(arg0 aws.Context, arg1 *ec2.ModifyInstanceCapacityReservationAttributesInput, arg2 ...request.Option) (*ec2.ModifyInstanceCapacityReservationAttributesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyInstanceCapacityReservationAttributesWithContext indicates an expected call of ModifyInstanceCapacityReservationAttributesWithContext
+func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributesWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributesWithContext), varargs...)
+}
+
+// ModifyInstanceCapacityReservationAttributesRequest mocks base method
+func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesRequest(arg0 *ec2.ModifyInstanceCapacityReservationAttributesInput) (*request.Request, *ec2.ModifyInstanceCapacityReservationAttributesOutput) {
+	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
+	return ret0, ret1
+}
+
+// ModifyInstanceCapacityReservationAttributesRequest indicates an expected call of ModifyInstanceCapacityReservationAttributesRequest
+func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributesRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributesRequest), arg0)
 }
 
 // ModifyInstanceCreditSpecification mocks base method
@@ -10868,6 +11293,50 @@ func (m *MockEC2API) MoveAddressToVpcRequest(arg0 *ec2.MoveAddressToVpcInput) (*
 // MoveAddressToVpcRequest indicates an expected call of MoveAddressToVpcRequest
 func (mr *MockEC2APIMockRecorder) MoveAddressToVpcRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAddressToVpcRequest", reflect.TypeOf((*MockEC2API)(nil).MoveAddressToVpcRequest), arg0)
+}
+
+// ProvisionByoipCidr mocks base method
+func (m *MockEC2API) ProvisionByoipCidr(arg0 *ec2.ProvisionByoipCidrInput) (*ec2.ProvisionByoipCidrOutput, error) {
+	ret := m.ctrl.Call(m, "ProvisionByoipCidr", arg0)
+	ret0, _ := ret[0].(*ec2.ProvisionByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ProvisionByoipCidr indicates an expected call of ProvisionByoipCidr
+func (mr *MockEC2APIMockRecorder) ProvisionByoipCidr(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidr", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidr), arg0)
+}
+
+// ProvisionByoipCidrWithContext mocks base method
+func (m *MockEC2API) ProvisionByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.ProvisionByoipCidrInput, arg2 ...request.Option) (*ec2.ProvisionByoipCidrOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ProvisionByoipCidrWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ProvisionByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ProvisionByoipCidrWithContext indicates an expected call of ProvisionByoipCidrWithContext
+func (mr *MockEC2APIMockRecorder) ProvisionByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidrWithContext), varargs...)
+}
+
+// ProvisionByoipCidrRequest mocks base method
+func (m *MockEC2API) ProvisionByoipCidrRequest(arg0 *ec2.ProvisionByoipCidrInput) (*request.Request, *ec2.ProvisionByoipCidrOutput) {
+	ret := m.ctrl.Call(m, "ProvisionByoipCidrRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ProvisionByoipCidrOutput)
+	return ret0, ret1
+}
+
+// ProvisionByoipCidrRequest indicates an expected call of ProvisionByoipCidrRequest
+func (mr *MockEC2APIMockRecorder) ProvisionByoipCidrRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidrRequest), arg0)
 }
 
 // PurchaseHostReservation mocks base method
@@ -12408,6 +12877,50 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 *ec2
 // UpdateSecurityGroupRuleDescriptionsIngressRequest indicates an expected call of UpdateSecurityGroupRuleDescriptionsIngressRequest
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsIngressRequest", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsIngressRequest), arg0)
+}
+
+// WithdrawByoipCidr mocks base method
+func (m *MockEC2API) WithdrawByoipCidr(arg0 *ec2.WithdrawByoipCidrInput) (*ec2.WithdrawByoipCidrOutput, error) {
+	ret := m.ctrl.Call(m, "WithdrawByoipCidr", arg0)
+	ret0, _ := ret[0].(*ec2.WithdrawByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WithdrawByoipCidr indicates an expected call of WithdrawByoipCidr
+func (mr *MockEC2APIMockRecorder) WithdrawByoipCidr(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidr", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidr), arg0)
+}
+
+// WithdrawByoipCidrWithContext mocks base method
+func (m *MockEC2API) WithdrawByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.WithdrawByoipCidrInput, arg2 ...request.Option) (*ec2.WithdrawByoipCidrOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WithdrawByoipCidrWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.WithdrawByoipCidrOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WithdrawByoipCidrWithContext indicates an expected call of WithdrawByoipCidrWithContext
+func (mr *MockEC2APIMockRecorder) WithdrawByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidrWithContext), varargs...)
+}
+
+// WithdrawByoipCidrRequest mocks base method
+func (m *MockEC2API) WithdrawByoipCidrRequest(arg0 *ec2.WithdrawByoipCidrInput) (*request.Request, *ec2.WithdrawByoipCidrOutput) {
+	ret := m.ctrl.Call(m, "WithdrawByoipCidrRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.WithdrawByoipCidrOutput)
+	return ret0, ret1
+}
+
+// WithdrawByoipCidrRequest indicates an expected call of WithdrawByoipCidrRequest
+func (mr *MockEC2APIMockRecorder) WithdrawByoipCidrRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidrRequest), arg0)
 }
 
 // WaitUntilBundleTaskComplete mocks base method

--- a/ec2/mock/sdk/ec2iface.go
+++ b/ec2/mock/sdk/ec2iface.go
@@ -167,50 +167,6 @@ func (mr *MockEC2APIMockRecorder) AcceptVpcPeeringConnectionRequest(arg0 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcPeeringConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcPeeringConnectionRequest), arg0)
 }
 
-// AdvertiseByoipCidr mocks base method
-func (m *MockEC2API) AdvertiseByoipCidr(arg0 *ec2.AdvertiseByoipCidrInput) (*ec2.AdvertiseByoipCidrOutput, error) {
-	ret := m.ctrl.Call(m, "AdvertiseByoipCidr", arg0)
-	ret0, _ := ret[0].(*ec2.AdvertiseByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AdvertiseByoipCidr indicates an expected call of AdvertiseByoipCidr
-func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidr(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidr", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidr), arg0)
-}
-
-// AdvertiseByoipCidrWithContext mocks base method
-func (m *MockEC2API) AdvertiseByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.AdvertiseByoipCidrInput, arg2 ...request.Option) (*ec2.AdvertiseByoipCidrOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "AdvertiseByoipCidrWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.AdvertiseByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AdvertiseByoipCidrWithContext indicates an expected call of AdvertiseByoipCidrWithContext
-func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidrWithContext), varargs...)
-}
-
-// AdvertiseByoipCidrRequest mocks base method
-func (m *MockEC2API) AdvertiseByoipCidrRequest(arg0 *ec2.AdvertiseByoipCidrInput) (*request.Request, *ec2.AdvertiseByoipCidrOutput) {
-	ret := m.ctrl.Call(m, "AdvertiseByoipCidrRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AdvertiseByoipCidrOutput)
-	return ret0, ret1
-}
-
-// AdvertiseByoipCidrRequest indicates an expected call of AdvertiseByoipCidrRequest
-func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidrRequest), arg0)
-}
-
 // AllocateAddress mocks base method
 func (m *MockEC2API) AllocateAddress(arg0 *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
 	ret := m.ctrl.Call(m, "AllocateAddress", arg0)
@@ -1047,50 +1003,6 @@ func (mr *MockEC2APIMockRecorder) CancelBundleTaskRequest(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelBundleTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CancelBundleTaskRequest), arg0)
 }
 
-// CancelCapacityReservation mocks base method
-func (m *MockEC2API) CancelCapacityReservation(arg0 *ec2.CancelCapacityReservationInput) (*ec2.CancelCapacityReservationOutput, error) {
-	ret := m.ctrl.Call(m, "CancelCapacityReservation", arg0)
-	ret0, _ := ret[0].(*ec2.CancelCapacityReservationOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CancelCapacityReservation indicates an expected call of CancelCapacityReservation
-func (mr *MockEC2APIMockRecorder) CancelCapacityReservation(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservation), arg0)
-}
-
-// CancelCapacityReservationWithContext mocks base method
-func (m *MockEC2API) CancelCapacityReservationWithContext(arg0 aws.Context, arg1 *ec2.CancelCapacityReservationInput, arg2 ...request.Option) (*ec2.CancelCapacityReservationOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "CancelCapacityReservationWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.CancelCapacityReservationOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CancelCapacityReservationWithContext indicates an expected call of CancelCapacityReservationWithContext
-func (mr *MockEC2APIMockRecorder) CancelCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservationWithContext), varargs...)
-}
-
-// CancelCapacityReservationRequest mocks base method
-func (m *MockEC2API) CancelCapacityReservationRequest(arg0 *ec2.CancelCapacityReservationInput) (*request.Request, *ec2.CancelCapacityReservationOutput) {
-	ret := m.ctrl.Call(m, "CancelCapacityReservationRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelCapacityReservationOutput)
-	return ret0, ret1
-}
-
-// CancelCapacityReservationRequest indicates an expected call of CancelCapacityReservationRequest
-func (mr *MockEC2APIMockRecorder) CancelCapacityReservationRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservationRequest), arg0)
-}
-
 // CancelConversionTask mocks base method
 func (m *MockEC2API) CancelConversionTask(arg0 *ec2.CancelConversionTaskInput) (*ec2.CancelConversionTaskOutput, error) {
 	ret := m.ctrl.Call(m, "CancelConversionTask", arg0)
@@ -1529,50 +1441,6 @@ func (m *MockEC2API) CopySnapshotRequest(arg0 *ec2.CopySnapshotInput) (*request.
 // CopySnapshotRequest indicates an expected call of CopySnapshotRequest
 func (mr *MockEC2APIMockRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySnapshotRequest", reflect.TypeOf((*MockEC2API)(nil).CopySnapshotRequest), arg0)
-}
-
-// CreateCapacityReservation mocks base method
-func (m *MockEC2API) CreateCapacityReservation(arg0 *ec2.CreateCapacityReservationInput) (*ec2.CreateCapacityReservationOutput, error) {
-	ret := m.ctrl.Call(m, "CreateCapacityReservation", arg0)
-	ret0, _ := ret[0].(*ec2.CreateCapacityReservationOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCapacityReservation indicates an expected call of CreateCapacityReservation
-func (mr *MockEC2APIMockRecorder) CreateCapacityReservation(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservation), arg0)
-}
-
-// CreateCapacityReservationWithContext mocks base method
-func (m *MockEC2API) CreateCapacityReservationWithContext(arg0 aws.Context, arg1 *ec2.CreateCapacityReservationInput, arg2 ...request.Option) (*ec2.CreateCapacityReservationOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "CreateCapacityReservationWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.CreateCapacityReservationOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCapacityReservationWithContext indicates an expected call of CreateCapacityReservationWithContext
-func (mr *MockEC2APIMockRecorder) CreateCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationWithContext), varargs...)
-}
-
-// CreateCapacityReservationRequest mocks base method
-func (m *MockEC2API) CreateCapacityReservationRequest(arg0 *ec2.CreateCapacityReservationInput) (*request.Request, *ec2.CreateCapacityReservationOutput) {
-	ret := m.ctrl.Call(m, "CreateCapacityReservationRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateCapacityReservationOutput)
-	return ret0, ret1
-}
-
-// CreateCapacityReservationRequest indicates an expected call of CreateCapacityReservationRequest
-func (mr *MockEC2APIMockRecorder) CreateCapacityReservationRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationRequest), arg0)
 }
 
 // CreateCustomerGateway mocks base method
@@ -4611,50 +4479,6 @@ func (mr *MockEC2APIMockRecorder) DeleteVpnGatewayRequest(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnGatewayRequest), arg0)
 }
 
-// DeprovisionByoipCidr mocks base method
-func (m *MockEC2API) DeprovisionByoipCidr(arg0 *ec2.DeprovisionByoipCidrInput) (*ec2.DeprovisionByoipCidrOutput, error) {
-	ret := m.ctrl.Call(m, "DeprovisionByoipCidr", arg0)
-	ret0, _ := ret[0].(*ec2.DeprovisionByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeprovisionByoipCidr indicates an expected call of DeprovisionByoipCidr
-func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidr(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidr", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidr), arg0)
-}
-
-// DeprovisionByoipCidrWithContext mocks base method
-func (m *MockEC2API) DeprovisionByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.DeprovisionByoipCidrInput, arg2 ...request.Option) (*ec2.DeprovisionByoipCidrOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DeprovisionByoipCidrWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.DeprovisionByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeprovisionByoipCidrWithContext indicates an expected call of DeprovisionByoipCidrWithContext
-func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidrWithContext), varargs...)
-}
-
-// DeprovisionByoipCidrRequest mocks base method
-func (m *MockEC2API) DeprovisionByoipCidrRequest(arg0 *ec2.DeprovisionByoipCidrInput) (*request.Request, *ec2.DeprovisionByoipCidrOutput) {
-	ret := m.ctrl.Call(m, "DeprovisionByoipCidrRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeprovisionByoipCidrOutput)
-	return ret0, ret1
-}
-
-// DeprovisionByoipCidrRequest indicates an expected call of DeprovisionByoipCidrRequest
-func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidrRequest), arg0)
-}
-
 // DeregisterImage mocks base method
 func (m *MockEC2API) DeregisterImage(arg0 *ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
 	ret := m.ctrl.Call(m, "DeregisterImage", arg0)
@@ -4917,94 +4741,6 @@ func (m *MockEC2API) DescribeBundleTasksRequest(arg0 *ec2.DescribeBundleTasksInp
 // DescribeBundleTasksRequest indicates an expected call of DescribeBundleTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeBundleTasksRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeBundleTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeBundleTasksRequest), arg0)
-}
-
-// DescribeByoipCidrs mocks base method
-func (m *MockEC2API) DescribeByoipCidrs(arg0 *ec2.DescribeByoipCidrsInput) (*ec2.DescribeByoipCidrsOutput, error) {
-	ret := m.ctrl.Call(m, "DescribeByoipCidrs", arg0)
-	ret0, _ := ret[0].(*ec2.DescribeByoipCidrsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeByoipCidrs indicates an expected call of DescribeByoipCidrs
-func (mr *MockEC2APIMockRecorder) DescribeByoipCidrs(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrs", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrs), arg0)
-}
-
-// DescribeByoipCidrsWithContext mocks base method
-func (m *MockEC2API) DescribeByoipCidrsWithContext(arg0 aws.Context, arg1 *ec2.DescribeByoipCidrsInput, arg2 ...request.Option) (*ec2.DescribeByoipCidrsOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DescribeByoipCidrsWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.DescribeByoipCidrsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeByoipCidrsWithContext indicates an expected call of DescribeByoipCidrsWithContext
-func (mr *MockEC2APIMockRecorder) DescribeByoipCidrsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrsWithContext), varargs...)
-}
-
-// DescribeByoipCidrsRequest mocks base method
-func (m *MockEC2API) DescribeByoipCidrsRequest(arg0 *ec2.DescribeByoipCidrsInput) (*request.Request, *ec2.DescribeByoipCidrsOutput) {
-	ret := m.ctrl.Call(m, "DescribeByoipCidrsRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeByoipCidrsOutput)
-	return ret0, ret1
-}
-
-// DescribeByoipCidrsRequest indicates an expected call of DescribeByoipCidrsRequest
-func (mr *MockEC2APIMockRecorder) DescribeByoipCidrsRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrsRequest), arg0)
-}
-
-// DescribeCapacityReservations mocks base method
-func (m *MockEC2API) DescribeCapacityReservations(arg0 *ec2.DescribeCapacityReservationsInput) (*ec2.DescribeCapacityReservationsOutput, error) {
-	ret := m.ctrl.Call(m, "DescribeCapacityReservations", arg0)
-	ret0, _ := ret[0].(*ec2.DescribeCapacityReservationsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeCapacityReservations indicates an expected call of DescribeCapacityReservations
-func (mr *MockEC2APIMockRecorder) DescribeCapacityReservations(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservations", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservations), arg0)
-}
-
-// DescribeCapacityReservationsWithContext mocks base method
-func (m *MockEC2API) DescribeCapacityReservationsWithContext(arg0 aws.Context, arg1 *ec2.DescribeCapacityReservationsInput, arg2 ...request.Option) (*ec2.DescribeCapacityReservationsOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DescribeCapacityReservationsWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.DescribeCapacityReservationsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeCapacityReservationsWithContext indicates an expected call of DescribeCapacityReservationsWithContext
-func (mr *MockEC2APIMockRecorder) DescribeCapacityReservationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservationsWithContext), varargs...)
-}
-
-// DescribeCapacityReservationsRequest mocks base method
-func (m *MockEC2API) DescribeCapacityReservationsRequest(arg0 *ec2.DescribeCapacityReservationsInput) (*request.Request, *ec2.DescribeCapacityReservationsOutput) {
-	ret := m.ctrl.Call(m, "DescribeCapacityReservationsRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeCapacityReservationsOutput)
-	return ret0, ret1
-}
-
-// DescribeCapacityReservationsRequest indicates an expected call of DescribeCapacityReservationsRequest
-func (mr *MockEC2APIMockRecorder) DescribeCapacityReservationsRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservationsRequest), arg0)
 }
 
 // DescribeClassicLinkInstances mocks base method
@@ -6722,35 +6458,6 @@ func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesRequest(arg0 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesRequest), arg0)
 }
 
-// DescribeNetworkInterfacesPages mocks base method
-func (m *MockEC2API) DescribeNetworkInterfacesPages(arg0 *ec2.DescribeNetworkInterfacesInput, arg1 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
-	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPages", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DescribeNetworkInterfacesPages indicates an expected call of DescribeNetworkInterfacesPages
-func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesPages(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesPages), arg0, arg1)
-}
-
-// DescribeNetworkInterfacesPagesWithContext mocks base method
-func (m *MockEC2API) DescribeNetworkInterfacesPagesWithContext(arg0 aws.Context, arg1 *ec2.DescribeNetworkInterfacesInput, arg2 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool, arg3 ...request.Option) error {
-	varargs := []interface{}{arg0, arg1, arg2}
-	for _, a := range arg3 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPagesWithContext", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DescribeNetworkInterfacesPagesWithContext indicates an expected call of DescribeNetworkInterfacesPagesWithContext
-func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesPagesWithContext), varargs...)
-}
-
 // DescribePlacementGroups mocks base method
 func (m *MockEC2API) DescribePlacementGroups(arg0 *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
 	ret := m.ctrl.Call(m, "DescribePlacementGroups", arg0)
@@ -6881,50 +6588,6 @@ func (m *MockEC2API) DescribePrincipalIdFormatRequest(arg0 *ec2.DescribePrincipa
 // DescribePrincipalIdFormatRequest indicates an expected call of DescribePrincipalIdFormatRequest
 func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormatRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormatRequest), arg0)
-}
-
-// DescribePublicIpv4Pools mocks base method
-func (m *MockEC2API) DescribePublicIpv4Pools(arg0 *ec2.DescribePublicIpv4PoolsInput) (*ec2.DescribePublicIpv4PoolsOutput, error) {
-	ret := m.ctrl.Call(m, "DescribePublicIpv4Pools", arg0)
-	ret0, _ := ret[0].(*ec2.DescribePublicIpv4PoolsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribePublicIpv4Pools indicates an expected call of DescribePublicIpv4Pools
-func (mr *MockEC2APIMockRecorder) DescribePublicIpv4Pools(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4Pools", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4Pools), arg0)
-}
-
-// DescribePublicIpv4PoolsWithContext mocks base method
-func (m *MockEC2API) DescribePublicIpv4PoolsWithContext(arg0 aws.Context, arg1 *ec2.DescribePublicIpv4PoolsInput, arg2 ...request.Option) (*ec2.DescribePublicIpv4PoolsOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DescribePublicIpv4PoolsWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.DescribePublicIpv4PoolsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribePublicIpv4PoolsWithContext indicates an expected call of DescribePublicIpv4PoolsWithContext
-func (mr *MockEC2APIMockRecorder) DescribePublicIpv4PoolsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4PoolsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4PoolsWithContext), varargs...)
-}
-
-// DescribePublicIpv4PoolsRequest mocks base method
-func (m *MockEC2API) DescribePublicIpv4PoolsRequest(arg0 *ec2.DescribePublicIpv4PoolsInput) (*request.Request, *ec2.DescribePublicIpv4PoolsOutput) {
-	ret := m.ctrl.Call(m, "DescribePublicIpv4PoolsRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribePublicIpv4PoolsOutput)
-	return ret0, ret1
-}
-
-// DescribePublicIpv4PoolsRequest indicates an expected call of DescribePublicIpv4PoolsRequest
-func (mr *MockEC2APIMockRecorder) DescribePublicIpv4PoolsRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4PoolsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4PoolsRequest), arg0)
 }
 
 // DescribeRegions mocks base method
@@ -10063,50 +9726,6 @@ func (mr *MockEC2APIMockRecorder) ImportVolumeRequest(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).ImportVolumeRequest), arg0)
 }
 
-// ModifyCapacityReservation mocks base method
-func (m *MockEC2API) ModifyCapacityReservation(arg0 *ec2.ModifyCapacityReservationInput) (*ec2.ModifyCapacityReservationOutput, error) {
-	ret := m.ctrl.Call(m, "ModifyCapacityReservation", arg0)
-	ret0, _ := ret[0].(*ec2.ModifyCapacityReservationOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModifyCapacityReservation indicates an expected call of ModifyCapacityReservation
-func (mr *MockEC2APIMockRecorder) ModifyCapacityReservation(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservation), arg0)
-}
-
-// ModifyCapacityReservationWithContext mocks base method
-func (m *MockEC2API) ModifyCapacityReservationWithContext(arg0 aws.Context, arg1 *ec2.ModifyCapacityReservationInput, arg2 ...request.Option) (*ec2.ModifyCapacityReservationOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ModifyCapacityReservationWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.ModifyCapacityReservationOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModifyCapacityReservationWithContext indicates an expected call of ModifyCapacityReservationWithContext
-func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationWithContext), varargs...)
-}
-
-// ModifyCapacityReservationRequest mocks base method
-func (m *MockEC2API) ModifyCapacityReservationRequest(arg0 *ec2.ModifyCapacityReservationInput) (*request.Request, *ec2.ModifyCapacityReservationOutput) {
-	ret := m.ctrl.Call(m, "ModifyCapacityReservationRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyCapacityReservationOutput)
-	return ret0, ret1
-}
-
-// ModifyCapacityReservationRequest indicates an expected call of ModifyCapacityReservationRequest
-func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationRequest), arg0)
-}
-
 // ModifyFleet mocks base method
 func (m *MockEC2API) ModifyFleet(arg0 *ec2.ModifyFleetInput) (*ec2.ModifyFleetOutput, error) {
 	ret := m.ctrl.Call(m, "ModifyFleet", arg0)
@@ -10413,50 +10032,6 @@ func (m *MockEC2API) ModifyInstanceAttributeRequest(arg0 *ec2.ModifyInstanceAttr
 // ModifyInstanceAttributeRequest indicates an expected call of ModifyInstanceAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceAttributeRequest), arg0)
-}
-
-// ModifyInstanceCapacityReservationAttributes mocks base method
-func (m *MockEC2API) ModifyInstanceCapacityReservationAttributes(arg0 *ec2.ModifyInstanceCapacityReservationAttributesInput) (*ec2.ModifyInstanceCapacityReservationAttributesOutput, error) {
-	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributes", arg0)
-	ret0, _ := ret[0].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModifyInstanceCapacityReservationAttributes indicates an expected call of ModifyInstanceCapacityReservationAttributes
-func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributes(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributes", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributes), arg0)
-}
-
-// ModifyInstanceCapacityReservationAttributesWithContext mocks base method
-func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesWithContext(arg0 aws.Context, arg1 *ec2.ModifyInstanceCapacityReservationAttributesInput, arg2 ...request.Option) (*ec2.ModifyInstanceCapacityReservationAttributesOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributesWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModifyInstanceCapacityReservationAttributesWithContext indicates an expected call of ModifyInstanceCapacityReservationAttributesWithContext
-func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributesWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributesWithContext), varargs...)
-}
-
-// ModifyInstanceCapacityReservationAttributesRequest mocks base method
-func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesRequest(arg0 *ec2.ModifyInstanceCapacityReservationAttributesInput) (*request.Request, *ec2.ModifyInstanceCapacityReservationAttributesOutput) {
-	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributesRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
-	return ret0, ret1
-}
-
-// ModifyInstanceCapacityReservationAttributesRequest indicates an expected call of ModifyInstanceCapacityReservationAttributesRequest
-func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributesRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributesRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributesRequest), arg0)
 }
 
 // ModifyInstanceCreditSpecification mocks base method
@@ -11293,50 +10868,6 @@ func (m *MockEC2API) MoveAddressToVpcRequest(arg0 *ec2.MoveAddressToVpcInput) (*
 // MoveAddressToVpcRequest indicates an expected call of MoveAddressToVpcRequest
 func (mr *MockEC2APIMockRecorder) MoveAddressToVpcRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAddressToVpcRequest", reflect.TypeOf((*MockEC2API)(nil).MoveAddressToVpcRequest), arg0)
-}
-
-// ProvisionByoipCidr mocks base method
-func (m *MockEC2API) ProvisionByoipCidr(arg0 *ec2.ProvisionByoipCidrInput) (*ec2.ProvisionByoipCidrOutput, error) {
-	ret := m.ctrl.Call(m, "ProvisionByoipCidr", arg0)
-	ret0, _ := ret[0].(*ec2.ProvisionByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ProvisionByoipCidr indicates an expected call of ProvisionByoipCidr
-func (mr *MockEC2APIMockRecorder) ProvisionByoipCidr(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidr", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidr), arg0)
-}
-
-// ProvisionByoipCidrWithContext mocks base method
-func (m *MockEC2API) ProvisionByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.ProvisionByoipCidrInput, arg2 ...request.Option) (*ec2.ProvisionByoipCidrOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ProvisionByoipCidrWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.ProvisionByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ProvisionByoipCidrWithContext indicates an expected call of ProvisionByoipCidrWithContext
-func (mr *MockEC2APIMockRecorder) ProvisionByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidrWithContext), varargs...)
-}
-
-// ProvisionByoipCidrRequest mocks base method
-func (m *MockEC2API) ProvisionByoipCidrRequest(arg0 *ec2.ProvisionByoipCidrInput) (*request.Request, *ec2.ProvisionByoipCidrOutput) {
-	ret := m.ctrl.Call(m, "ProvisionByoipCidrRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ProvisionByoipCidrOutput)
-	return ret0, ret1
-}
-
-// ProvisionByoipCidrRequest indicates an expected call of ProvisionByoipCidrRequest
-func (mr *MockEC2APIMockRecorder) ProvisionByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidrRequest), arg0)
 }
 
 // PurchaseHostReservation mocks base method
@@ -12877,50 +12408,6 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 *ec2
 // UpdateSecurityGroupRuleDescriptionsIngressRequest indicates an expected call of UpdateSecurityGroupRuleDescriptionsIngressRequest
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsIngressRequest", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsIngressRequest), arg0)
-}
-
-// WithdrawByoipCidr mocks base method
-func (m *MockEC2API) WithdrawByoipCidr(arg0 *ec2.WithdrawByoipCidrInput) (*ec2.WithdrawByoipCidrOutput, error) {
-	ret := m.ctrl.Call(m, "WithdrawByoipCidr", arg0)
-	ret0, _ := ret[0].(*ec2.WithdrawByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WithdrawByoipCidr indicates an expected call of WithdrawByoipCidr
-func (mr *MockEC2APIMockRecorder) WithdrawByoipCidr(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidr", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidr), arg0)
-}
-
-// WithdrawByoipCidrWithContext mocks base method
-func (m *MockEC2API) WithdrawByoipCidrWithContext(arg0 aws.Context, arg1 *ec2.WithdrawByoipCidrInput, arg2 ...request.Option) (*ec2.WithdrawByoipCidrOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "WithdrawByoipCidrWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.WithdrawByoipCidrOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WithdrawByoipCidrWithContext indicates an expected call of WithdrawByoipCidrWithContext
-func (mr *MockEC2APIMockRecorder) WithdrawByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidrWithContext), varargs...)
-}
-
-// WithdrawByoipCidrRequest mocks base method
-func (m *MockEC2API) WithdrawByoipCidrRequest(arg0 *ec2.WithdrawByoipCidrInput) (*request.Request, *ec2.WithdrawByoipCidrOutput) {
-	ret := m.ctrl.Call(m, "WithdrawByoipCidrRequest", arg0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.WithdrawByoipCidrOutput)
-	return ret0, ret1
-}
-
-// WithdrawByoipCidrRequest indicates an expected call of WithdrawByoipCidrRequest
-func (mr *MockEC2APIMockRecorder) WithdrawByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidrRequest), arg0)
 }
 
 // WaitUntilBundleTaskComplete mocks base method

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -274,7 +274,7 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 				PendingCount: aws.Int64Value(d.PendingCount),
 				RunningCount: aws.Int64Value(d.RunningCount),
 				CreatedAt:    aws.TimeValue(d.CreatedAt),
-				Id:           ecs.GetDeploymentId(aws.StringValue(d.TaskDefinition)),
+				Id:           ecs.GetRevisionNumber(aws.StringValue(d.TaskDefinition)),
 			}
 
 			deploymentTaskDefinition := ecs.DescribeTaskDefinition(aws.StringValue(d.TaskDefinition))

--- a/ecs/task.go
+++ b/ecs/task.go
@@ -206,7 +206,7 @@ func (ecs *ECS) DescribeTasks(taskIds []string) []Task {
 		task := Task{
 			Cpu:           aws.StringValue(t.Cpu),
 			CreatedAt:     aws.TimeValue(t.CreatedAt),
-			DeploymentId:  ecs.GetDeploymentId(aws.StringValue(t.TaskDefinitionArn)),
+			DeploymentId:  ecs.GetRevisionNumber(aws.StringValue(t.TaskDefinitionArn)),
 			DesiredStatus: aws.StringValue(t.DesiredStatus),
 			LastStatus:    aws.StringValue(t.LastStatus),
 			Memory:        aws.StringValue(t.Memory),

--- a/ecs/task_definition.go
+++ b/ecs/task_definition.go
@@ -126,46 +126,49 @@ func (ecs *ECS) DescribeTaskDefinition(taskDefinitionArn string) *awsecs.TaskDef
 	return taskDefinitionCache[taskDefinitionArn]
 }
 
+//UpdateTaskDefinitionImage registers a new task definition with the updated image
 func (ecs *ECS) UpdateTaskDefinitionImage(taskDefinitionArn, image string) string {
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
 	taskDefinition.ContainerDefinitions[0].Image = aws.String(image)
-
-	resp, err := ecs.svc.RegisterTaskDefinition(
-		&awsecs.RegisterTaskDefinitionInput{
-			ContainerDefinitions:    taskDefinition.ContainerDefinitions,
-			Cpu:                     taskDefinition.Cpu,
-			ExecutionRoleArn:        taskDefinition.ExecutionRoleArn,
-			Family:                  taskDefinition.Family,
-			Memory:                  taskDefinition.Memory,
-			NetworkMode:             taskDefinition.NetworkMode,
-			RequiresCompatibilities: taskDefinition.RequiresCompatibilities,
-			TaskRoleArn:             taskDefinition.TaskRoleArn,
-		},
-	)
-
-	if err != nil {
-		console.ErrorExit(err, "Could not register ECS task definition")
-	}
-
-	return aws.StringValue(resp.TaskDefinition.TaskDefinitionArn)
+	return ecs.registerTaskDefinition(taskDefinition)
 }
 
-// UpdateTaskDefinitionImageAndEnvVars creates a new, updated task definition
-// based on the specified image and env vars
-func (ecs *ECS) UpdateTaskDefinitionImageAndEnvVars(taskDefinitionArn, image string, environmentVariables map[string]string) string {
+// UpdateTaskDefinitionImageAndReplaceEnvVars creates a new, updated task definition
+// based on the specified image and env vars.
+// Note that any existing envvars are replaced by the new ones
+func (ecs *ECS) UpdateTaskDefinitionImageAndEnvVars(taskDefinitionArnOrFamily string, image string, environmentVariables []EnvVar, replaceEnvVars bool) string {
 
-	//fetch current task definition
-	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
+	//fetch task definition details (for specific or latest active)
+	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArnOrFamily)
 
-	//update image
-	taskDefinition.ContainerDefinitions[0].Image = aws.String(image)
+	//which container are we updating?
+	container := taskDefinition.ContainerDefinitions[0]
 
-	//update env vars
-	envvars := []EnvVar{}
-	for k, v := range environmentVariables {
-		envvars = append(envvars, EnvVar{Key: k, Value: v})
+	//update image if specified
+	if image != "" {
+		container.Image = aws.String(image)
 	}
-	taskDefinition.ContainerDefinitions[0].Environment = convertEnvVars(envvars)
+
+	//convert envvars to aws input format
+	if len(environmentVariables) > 0 {
+		envvars := convertEnvVars(environmentVariables)
+
+		//is this a replace or add operation?
+		if replaceEnvVars {
+			container.Environment = envvars
+
+		} else {
+			for _, e := range envvars {
+				container.Environment = append(container.Environment, e)
+			}
+		}
+	}
+
+	return ecs.registerTaskDefinition(taskDefinition)
+}
+
+//registers a new task definition based on a task definition struct
+func (ecs *ECS) registerTaskDefinition(taskDefinition *awsecs.TaskDefinition) string {
 
 	//register a new task definition
 	resp, err := ecs.svc.RegisterTaskDefinition(
@@ -179,15 +182,16 @@ func (ecs *ECS) UpdateTaskDefinitionImageAndEnvVars(taskDefinitionArn, image str
 			RequiresCompatibilities: taskDefinition.RequiresCompatibilities,
 			TaskRoleArn:             taskDefinition.TaskRoleArn,
 		},
-	)
+	)	
 
 	if err != nil {
 		console.ErrorExit(err, "Could not register ECS task definition")
 	}
 
-	return aws.StringValue(resp.TaskDefinition.TaskDefinitionArn)
+	return aws.StringValue(resp.TaskDefinition.TaskDefinitionArn)	
 }
 
+//AddEnvVarsToTaskDefinition registers a new task definition with the envvars appended
 func (ecs *ECS) AddEnvVarsToTaskDefinition(taskDefinitionArn string, envVars []EnvVar) string {
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
 
@@ -203,24 +207,7 @@ func (ecs *ECS) AddEnvVarsToTaskDefinition(taskDefinitionArn string, envVars []E
 		)
 	}
 
-	resp, err := ecs.svc.RegisterTaskDefinition(
-		&awsecs.RegisterTaskDefinitionInput{
-			ContainerDefinitions:    taskDefinition.ContainerDefinitions,
-			Cpu:                     taskDefinition.Cpu,
-			ExecutionRoleArn:        taskDefinition.ExecutionRoleArn,
-			Family:                  taskDefinition.Family,
-			Memory:                  taskDefinition.Memory,
-			NetworkMode:             taskDefinition.NetworkMode,
-			RequiresCompatibilities: taskDefinition.RequiresCompatibilities,
-			TaskRoleArn:             taskDefinition.TaskRoleArn,
-		},
-	)
-
-	if err != nil {
-		console.ErrorExit(err, "Could not register ECS task definition")
-	}
-
-	return aws.StringValue(resp.TaskDefinition.TaskDefinitionArn)
+	return ecs.registerTaskDefinition(taskDefinition)
 }
 
 //RemoveEnvVarsFromTaskDefinition registers a new task definition with the specified keys removed
@@ -251,26 +238,10 @@ func (ecs *ECS) RemoveEnvVarsFromTaskDefinition(taskDefinitionArn string, keys [
 
 	taskDefinition.ContainerDefinitions[0].Environment = newEnvironment
 
-	resp, err := ecs.svc.RegisterTaskDefinition(
-		&awsecs.RegisterTaskDefinitionInput{
-			ContainerDefinitions:    taskDefinition.ContainerDefinitions,
-			Cpu:                     taskDefinition.Cpu,
-			ExecutionRoleArn:        taskDefinition.ExecutionRoleArn,
-			Family:                  taskDefinition.Family,
-			Memory:                  taskDefinition.Memory,
-			NetworkMode:             taskDefinition.NetworkMode,
-			RequiresCompatibilities: taskDefinition.RequiresCompatibilities,
-			TaskRoleArn:             taskDefinition.TaskRoleArn,
-		},
-	)
-
-	if err != nil {
-		console.ErrorExit(err, "Could not register ECS task definition")
-	}
-
-	return aws.StringValue(resp.TaskDefinition.TaskDefinitionArn)
+	return ecs.registerTaskDefinition(taskDefinition)
 }
 
+//GetEnvVarsFromTaskDefinition retrieves envvars from an existing task definition
 func (ecs *ECS) GetEnvVarsFromTaskDefinition(taskDefinitionArn string) []EnvVar {
 	var envVars []EnvVar
 
@@ -288,6 +259,7 @@ func (ecs *ECS) GetEnvVarsFromTaskDefinition(taskDefinitionArn string) []EnvVar 
 	return envVars
 }
 
+//UpdateTaskDefinitionCpuAndMemory registers a new task definition with the cpu/memory
 func (ecs *ECS) UpdateTaskDefinitionCpuAndMemory(taskDefinitionArn, cpu, memory string) string {
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
 
@@ -299,31 +271,16 @@ func (ecs *ECS) UpdateTaskDefinitionCpuAndMemory(taskDefinitionArn, cpu, memory 
 		taskDefinition.Memory = aws.String(memory)
 	}
 
-	resp, err := ecs.svc.RegisterTaskDefinition(
-		&awsecs.RegisterTaskDefinitionInput{
-			ContainerDefinitions:    taskDefinition.ContainerDefinitions,
-			Cpu:                     taskDefinition.Cpu,
-			ExecutionRoleArn:        taskDefinition.ExecutionRoleArn,
-			Family:                  taskDefinition.Family,
-			Memory:                  taskDefinition.Memory,
-			NetworkMode:             taskDefinition.NetworkMode,
-			RequiresCompatibilities: taskDefinition.RequiresCompatibilities,
-			TaskRoleArn:             taskDefinition.TaskRoleArn,
-		},
-	)
-
-	if err != nil {
-		console.ErrorExit(err, "Could not register ECS task definition")
-	}
-
-	return aws.StringValue(resp.TaskDefinition.TaskDefinitionArn)
+	return ecs.registerTaskDefinition(taskDefinition)
 }
 
+//GetDeploymentId returns the deployment id from a task definition
 func (ecs *ECS) GetDeploymentId(taskDefinitionArn string) string {
 	contents := strings.Split(taskDefinitionArn, ":")
 	return contents[len(contents)-1]
 }
 
+//GetCpuAndMemoryFromTaskDefinition returns the cpu/memory from a task definition
 func (ecs *ECS) GetCpuAndMemoryFromTaskDefinition(taskDefinitionArn string) (string, string) {
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
 

--- a/ecs/task_definition.go
+++ b/ecs/task_definition.go
@@ -274,8 +274,8 @@ func (ecs *ECS) UpdateTaskDefinitionCpuAndMemory(taskDefinitionArn, cpu, memory 
 	return ecs.registerTaskDefinition(taskDefinition)
 }
 
-//GetDeploymentId returns the deployment id from a task definition
-func (ecs *ECS) GetDeploymentId(taskDefinitionArn string) string {
+//GetRevisionNumber returns the revision number from a task definition
+func (ecs *ECS) GetRevisionNumber(taskDefinitionArn string) string {
 	contents := strings.Split(taskDefinitionArn, ":")
 	return contents[len(contents)-1]
 }


### PR DESCRIPTION
```
Registers a new task definition revision for the specified docker image or environment variables based on the latest revision of the task family and returns the new revision number.

Usage:
  fargate task register [flags]

Examples:

fargate task register --image 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app:0.1.0
fargate task register --image 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app:0.1.0 --env FOO=bar --env BAR=baz
fargate task register --env-file dev.env
fargate task register --file docker-compose.yml


Flags:
  -e, --env stringArray   Environment variables to set [e.g. -e KEY=value -e KEY2=value]
      --env-file string   File containing list of environment variables to set, one per line, of the form KEY=value
  -f, --file string       Docker Compose file containing image and environment variables to register.
  -h, --help              help for register
  -i, --image string      Docker image to register

Global Flags:
  -c, --cluster string   ECS cluster name
      --no-emoji         Disable emoji output
      --nocolor          Disable color output
      --region string    AWS region (default "us-east-1")
  -t, --task string      ECS task family name
  -v, --verbose          Verbose output
```