### PR TITLE
implements task logs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ until you manually stop them either through AWS APIs, the AWS Management
 Console, or until they are interrupted for any reason.
 
 - [register](#fargate-task-register)
+- [logs](#fargate-task-logs)
 
 
 ##### fargate task register
@@ -337,6 +338,50 @@ fargate task register [--file docker-compose.yml]
 Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) using the [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file. Note that environments variables are replaced with what's in the compose file.
 
 If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy.
+
+##### fargate task logs
+
+```console
+fargate task logs [--follow] [--start <time-expression>] [--end <time-expression>]
+                  [--filter <filter-expression>] [--task <task-id>] 
+                  [--container-name] [--time] [--no-prefix]
+```
+
+Show logs from tasks
+
+Assumes a cloudwatch log group with the following convention: `fargate/task/<task>`
+where `task` is specified via `--task`, or fargate.yml, or environment variable [options](#options)
+
+Return either a specific segment of task logs or tail logs in real-time using
+the --follow option. Logs are prefixed by their log stream name which is in the
+format of `fargate/<container-name>/<task-id>.`
+
+`--container-name` allows you to specifiy the container within the task definition to get logs for
+(defaults to `app`)
+
+Follow will continue to run and return logs until interrupted by Control-C. If
+`--follow` is passed `--end` cannot be specified.
+
+Logs can be returned for specific tasks by passing a task
+ID via the `--task` flag. Pass `--task` with a task ID multiple times in order to
+retrieve logs from multiple specific tasks.
+
+A specific window of logs can be requested by passing `--start` and `--end` options
+with a time expression. The time expression can be either a duration or a
+timestamp:
+
+  - Duration (e.g. -1h [one hour ago], -1h10m30s [one hour, ten minutes, and
+    thirty seconds ago], 2h [two hours from now])
+  - Timestamp with optional timezone in the format of YYYY-MM-DD HH:MM:SS [TZ];
+    timezone will default to UTC if omitted (e.g. 2017-12-22 15:10:03 EST)
+
+You can filter logs for specific term by passing a filter expression via the
+`--filter` flag. Pass a single term to search for that term, pass multiple terms
+to search for log messages that include all terms.
+
+`--time` includes the log timestamp in the output
+
+`--no-prefix` excludes the log stream prefix from the output
 
 
 #### Events

--- a/cloudwatchlogs/log_group.go
+++ b/cloudwatchlogs/log_group.go
@@ -91,7 +91,7 @@ func (cwl *CloudWatchLogs) GetLogs(i *GetLogsInput) []LogLine {
 	)
 
 	if err != nil {
-		console.ErrorExit(err, "Could not get logs")
+		console.ErrorExit(err, "Could not get logs for: " + i.LogGroupName)
 	}
 
 	return logLines

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -21,15 +21,17 @@ const (
 type Empty struct{}
 
 type GetLogsOperation struct {
-	LogGroupName    string
-	Namespace       string
-	EndTime         time.Time
-	Filter          string
-	Follow          bool
-	LogStreamColors map[string]int
-	LogStreamNames  []string
-	StartTime       time.Time
-	EventCache      *lru.Cache
+	LogGroupName      string
+	Namespace         string
+	EndTime           time.Time
+	Filter            string
+	Follow            bool
+	LogStreamColors   map[string]int
+	LogStreamNames    []string
+	StartTime         time.Time
+	EventCache        *lru.Cache
+	IncludeTime       bool
+	NoLogStreamPrefix bool
 }
 
 func (o *GetLogsOperation) AddStartTime(rawStartTime string) {
@@ -141,10 +143,18 @@ func getLogs(operation *GetLogsOperation) {
 	}
 
 	for _, logLine := range cwl.GetLogs(input) {
+
+		//format time if needed
+		var logTime string
+		if operation.IncludeTime {
+			logTime = logLine.Timestamp.Format(time.RFC3339)
+		}
+
+		// logLine.Timestamp
 		streamColor := operation.GetStreamColor(logLine.LogStreamName)
 
 		if !operation.SeenEvent(logLine.EventId) {
-			console.LogLine(logLine.LogStreamName, logLine.Message, streamColor)
+			console.LogLine(logLine.LogStreamName, logLine.Message, streamColor, logTime, operation.NoLogStreamPrefix)
 		}
 	}
 }

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// const taskLogGroupFormat = "/fargate/task/%s"
+const taskLogGroupFormat = "/fargate/task/%s"
 
 var taskCmd = &cobra.Command{
 	Use:   "task",

--- a/cmd/task_logs.go
+++ b/cmd/task_logs.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagTaskLogsFilter            string
+	flagTaskLogsEndTime           string
+	flagTaskLogsStartTime         string
+	flagTaskLogsFollow            bool
+	flagTaskLogsTasks             []string
+	flagTaskLogsContainerName     string
+	flagTaskLogsTime              bool
+	flagTaskLogsNoLogStreamPrefix bool
+)
+
+var taskLogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Show logs from tasks",
+	Long: `Show logs from tasks
+
+Assumes a cloudwatch log group with the following convention: fargate/task/<task>
+where task is specified via --task, or fargate.yml, or environment variable options
+
+Return either a specific segment of task logs or tail logs in real-time using
+the --follow option. Logs are prefixed by their log stream name which is in the
+format of fargate/<container-name>/<task-id>.
+
+--container-name allows you to specifiy the container within the task definition to get logs for
+(defaults to app)
+
+Follow will continue to run and return logs until interrupted by Control-C. If
+--follow is passed --end cannot be specified.
+
+Logs can be returned for specific tasks by passing a task
+ID via the --task flag. Pass --task with a task ID multiple times in order to
+retrieve logs from multiple specific tasks.
+
+A specific window of logs can be requested by passing --start and --end options
+with a time expression. The time expression can be either a duration or a
+timestamp:
+
+	- Duration (e.g. -1h [one hour ago], -1h10m30s [one hour, ten minutes, and
+		thirty seconds ago], 2h [two hours from now])
+	- Timestamp with optional timezone in the format of YYYY-MM-DD HH:MM:SS [TZ];
+		timezone will default to UTC if omitted (e.g. 2017-12-22 15:10:03 EST)
+
+You can filter logs for specific term by passing a filter expression via the
+--filter flag. Pass a single term to search for that term, pass multiple terms
+to search for log messages that include all terms.
+
+--time includes the log timestamp in the output
+
+--no-prefix excludes the log stream prefix from the output
+`,
+	Example: `
+fargate task logs
+fargate task logs --follow
+fargate task logs --start "-10m"
+fargate task logs --time --no-prefix
+fargate task logs --task my-task-dev --container-name my-container
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		operation := &GetLogsOperation{
+			LogGroupName:      fmt.Sprintf(taskLogGroupFormat, getTaskName()),
+			Filter:            flagTaskLogsFilter,
+			Follow:            flagTaskLogsFollow,
+			Namespace:         flagTaskLogsContainerName,
+			IncludeTime:       flagTaskLogsTime,
+			NoLogStreamPrefix: flagTaskLogsNoLogStreamPrefix,
+		}
+
+		operation.AddTasks(flagTaskLogsTasks)
+		operation.AddStartTime(flagTaskLogsStartTime)
+		operation.AddEndTime(flagTaskLogsEndTime)
+
+		GetLogs(operation)
+	},
+}
+
+func init() {
+	taskCmd.AddCommand(taskLogsCmd)
+
+	taskLogsCmd.Flags().BoolVarP(&flagTaskLogsFollow, "follow", "f", false, "Poll logs and continuously print new events")
+	taskLogsCmd.Flags().StringVar(&flagTaskLogsFilter, "filter", "", "Filter pattern to apply")
+	taskLogsCmd.Flags().StringVar(&flagTaskLogsStartTime, "start", "", "Earliest time to return logs (e.g. -1h, 2018-01-01 09:36:00 EST")
+	taskLogsCmd.Flags().StringVar(&flagTaskLogsEndTime, "end", "", "Latest time to return logs (e.g. 3y, 2021-01-20 12:00:00 EST")
+	taskLogsCmd.Flags().StringSliceVarP(&flagTaskLogsTasks, "task", "t", []string{}, "Show logs from specific task (can be specified multiple times)")
+	taskLogsCmd.Flags().StringVarP(&flagTaskLogsContainerName, "container-name", "n", "app", "name of container in task defintion to get logs for")
+	taskLogsCmd.PersistentFlags().BoolVarP(&flagTaskLogsTime, "time", "T", false, "append time to logs")
+	taskLogsCmd.PersistentFlags().BoolVarP(&flagTaskLogsNoLogStreamPrefix, "no-prefix", "", false, "don't include log stream prefix in output")
+}

--- a/console/main.go
+++ b/console/main.go
@@ -33,7 +33,13 @@ var (
 	orange = ansi.ColorCode("214+bh")
 )
 
-func LogLine(prefix, msg string, color int) {
+func LogLine(prefix, msg string, color int, time string, excludePrefix bool) {
+	if excludePrefix {
+		prefix = ""
+	}
+	if time != "" {
+		prefix += " " + time
+	}
 	if Color {
 		colorCode := strconv.Itoa(color)
 		fmt.Println(ansi.ColorCode(colorCode) + prefix + reset + " " + msg)


### PR DESCRIPTION
```
Show logs from tasks

Assumes a cloudwatch log group with the following convention: fargate/task/<task>
where task is specified via --task, or fargate.yml, or environment variable options

Return either a specific segment of task logs or tail logs in real-time using
the --follow option. Logs are prefixed by their log stream name which is in the
format of fargate/<container-name>/<task-id>.

--container-name allows you to specifiy the container within the task definition to get logs for
(defaults to app)

Follow will continue to run and return logs until interrupted by Control-C. If
--follow is passed --end cannot be specified.

Logs can be returned for specific tasks by passing a task
ID via the --task flag. Pass --task with a task ID multiple times in order to
retrieve logs from multiple specific tasks.

A specific window of logs can be requested by passing --start and --end options
with a time expression. The time expression can be either a duration or a
timestamp:

        - Duration (e.g. -1h [one hour ago], -1h10m30s [one hour, ten minutes, and
                thirty seconds ago], 2h [two hours from now])
        - Timestamp with optional timezone in the format of YYYY-MM-DD HH:MM:SS [TZ];
                timezone will default to UTC if omitted (e.g. 2017-12-22 15:10:03 EST)

You can filter logs for specific term by passing a filter expression via the
--filter flag. Pass a single term to search for that term, pass multiple terms
to search for log messages that include all terms.

--time includes the log timestamp in the output

--no-prefix excludes the log stream prefix from the output

Usage:
  fargate task logs [flags]

Examples:

fargate task logs
fargate task logs --follow
fargate task logs --start "-10m"
fargate task logs --time --no-prefix
fargate task logs --task my-task-dev --container-name my-container


Flags:
  -n, --container-name string   name of container in task defintion to get logs for (default "app")
      --end string              Latest time to return logs (e.g. 3y, 2021-01-20 12:00:00 EST
      --filter string           Filter pattern to apply
  -f, --follow                  Poll logs and continuously print new events
  -h, --help                    help for logs
      --no-prefix               don't include log stream prefix in output
      --start string            Earliest time to return logs (e.g. -1h, 2018-01-01 09:36:00 EST
  -T, --time                    append time to logs
```