### PR TITLE
adds --time and --no-prefix to service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ update to configuration such a CPU, memory, or environment variables.
 ```console
 fargate service logs [--follow] [--start <time-expression>] [--end <time-expression>]
                      [--filter <filter-expression>] [--task <task-id>]
+                     [--time] [--no-prefix]
 ```
 
 Show logs from tasks in a service
@@ -203,6 +204,10 @@ You can filter logs for specific term by passing a filter expression via the
 --filter flag. Pass a single term to search for that term, pass multiple terms
 to search for log messages that include all terms. See the [CloudWatch Logs
 documentation][cwl-filter-expression] for more details.
+
+--time includes the log timestamp in the output
+
+--no-prefix excludes the log stream prefix from the output
 
 ##### fargate service ps
 

--- a/cmd/service_logs.go
+++ b/cmd/service_logs.go
@@ -7,11 +7,13 @@ import (
 )
 
 var (
-	flagServiceLogsFilter    string
-	flagServiceLogsEndTime   string
-	flagServiceLogsStartTime string
-	flagServiceLogsFollow    bool
-	flagServiceLogsTasks     []string
+	flagServiceLogsFilter            string
+	flagServiceLogsEndTime           string
+	flagServiceLogsStartTime         string
+	flagServiceLogsFollow            bool
+	flagServiceLogsTasks             []string
+	flagServiceLogsTime              bool
+	flagServiceLogsNoLogStreamPrefix bool
 )
 
 var serviceLogsCmd = &cobra.Command{
@@ -41,15 +43,22 @@ timestamp:
 
 You can filter logs for specific term by passing a filter expression via the
 --filter flag. Pass a single term to search for that term, pass multiple terms
-to search for log messages that include all terms.`,
+to search for log messages that include all terms.
+
+--time includes the log timestamp in the output
+
+--no-prefix excludes the log stream prefix from the output
+`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &GetLogsOperation{
-			LogGroupName: fmt.Sprintf(serviceLogGroupFormat, getServiceName()),
-			Filter:       flagServiceLogsFilter,
-			Follow:       flagServiceLogsFollow,
-			Namespace:    getServiceName(),
+			LogGroupName:      fmt.Sprintf(serviceLogGroupFormat, getServiceName()),
+			Filter:            flagServiceLogsFilter,
+			Follow:            flagServiceLogsFollow,
+			Namespace:         getServiceName(),
+			IncludeTime:       flagServiceLogsTime,
+			NoLogStreamPrefix: flagServiceLogsNoLogStreamPrefix,
 		}
 
 		operation.AddTasks(flagServiceLogsTasks)
@@ -68,4 +77,6 @@ func init() {
 	serviceLogsCmd.Flags().StringVar(&flagServiceLogsStartTime, "start", "", "Earliest time to return logs (e.g. -1h, 2018-01-01 09:36:00 EST")
 	serviceLogsCmd.Flags().StringVar(&flagServiceLogsEndTime, "end", "", "Latest time to return logs (e.g. 3y, 2021-01-20 12:00:00 EST")
 	serviceLogsCmd.Flags().StringSliceVarP(&flagServiceLogsTasks, "task", "t", []string{}, "Show logs from specific task (can be specified multiple times)")
+	serviceLogsCmd.PersistentFlags().BoolVarP(&flagServiceLogsTime, "time", "T", false, "append time to logs")
+	serviceLogsCmd.PersistentFlags().BoolVarP(&flagServiceLogsNoLogStreamPrefix, "no-prefix", "", false, "don't include log stream prefix in output")
 }

--- a/console/main.go
+++ b/console/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/mgutz/ansi"
 )
@@ -33,19 +34,25 @@ var (
 	orange = ansi.ColorCode("214+bh")
 )
 
+//LogLine prints a log line to the console
 func LogLine(prefix, msg string, color int, time string, excludePrefix bool) {
+	var colorCode, resetCode string
+
 	if excludePrefix {
 		prefix = ""
 	}
-	if time != "" {
-		prefix += " " + time
-	}
 	if Color {
-		colorCode := strconv.Itoa(color)
-		fmt.Println(ansi.ColorCode(colorCode) + prefix + reset + " " + msg)
-	} else {
-		fmt.Println(prefix + " " + msg)
+		colorCode = ansi.ColorCode(strconv.Itoa(color))
+		resetCode = reset
 	}
+
+	//add space to msg if there's something before it
+	if prefix != "" || time != "" {
+		msg = " " + msg
+	}
+
+	payload := fmt.Sprintf("%v%v%v%v%v", colorCode, prefix, time, resetCode, msg)
+	fmt.Println(strings.TrimSpace(payload))
 }
 
 func KeyValue(key, value string, a ...interface{}) {


### PR DESCRIPTION
```shell
fargate service logs --time
ecs/harbor-shipit-metrics/245b5bbd-4457-4cca-83bf-1cd7c47dfdcd2018-11-06T13:09:14-05:00 {"msg":"pushMetrics"}
ecs/harbor-shipit-metrics/245b5bbd-4457-4cca-83bf-1cd7c47dfdcd2018-11-06T13:09:14-05:00 {"msg":"fetching metrics from shipit"}
ecs/harbor-shipit-metrics/245b5bbd-4457-4cca-83bf-1cd7c47dfdcd2018-11-06T13:09:14-05:00 {"msg":"fetching/calculating monthly lb costs"}
```

```shell
fargate service logs --no-prefix
{"msg":"pushMetrics"}
{"msg":"fetching metrics from shipit"}
{"msg":"fetching/calculating monthly lb costs"}
```

```shell
fargate service logs --no-prefix --time
2018-11-06T13:09:14-05:00 {"msg":"pushMetrics"}
2018-11-06T13:09:14-05:00 {"msg":"fetching metrics from shipit"}
2018-11-06T13:09:14-05:00 {"msg":"fetching/calculating monthly lb costs"}
```