### PR TITLE
added --revision flag to `service deploy` cmd

### DIFF
--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -56,6 +56,12 @@ fargate service deploy -r 37
 			ComposeFile: flagServiceDeployDockerComposeFile,
 			Revision:    flagServiceDeployRevision,
 		}
+
+		if !validateFlags(operation) {
+			cmd.Help()
+			return
+		}
+
 		deployService(operation)
 	},
 }
@@ -176,4 +182,20 @@ func getDockerServiceToDeploy(dc *dockercompose.DockerCompose) (string, *dockerc
 		}
 	}
 	return name, service
+}
+
+//Check incompatible flag combinations
+func validateFlags(operation *ServiceDeployOperation) bool {
+	strFlags := []string{operation.Image, operation.ComposeFile, operation.Revision}
+	setFlags := make([]string, 0)
+
+	for _, v := range strFlags {
+		if v != "" {
+			setFlags = append(setFlags, v)
+		}
+	}
+
+	valid := len(setFlags) == 1
+
+	return valid
 }

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -39,7 +39,8 @@ docker-compose.yml file will be deployed.
 
 A task definition revision can be specified via the --revision flag.
 The revision number can either be absolute or a delta specified with a sign
-such as +5 or -2. Where -2 is to say "rollback to 2 configurations ago."
+such as +5 or -2, where -2 is "2 configurations ago" from the current
+deployed revision.
 `,
 	Example: `
 fargate service deploy -i 123456789.dkr.ecr.us-east-1.amazonaws.com/my-service:1.0

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -132,6 +132,11 @@ func deployRevision(operation *ServiceDeployOperation) {
 
 	//build full task definiton arn with revision
 	revisionNumber := ecs.ResolveRevisionNumber(service.TaskDefinitionArn, operation.Revision)
+
+	if revisionNumber == "" {
+		console.IssueExit("Could not resolve revision number")
+	}
+
 	taskDefinitionArn := ecs.GetTaskDefinitionARN(operation.Region, account, operation.Task, revisionNumber)
 
 	ecs.UpdateServiceTaskDefinition(operation.ServiceName, taskDefinitionArn)

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -15,7 +15,6 @@ type ServiceDeployOperation struct {
 	ComposeFile string
 	Region      string
 	Revision    string
-	Task        string
 }
 
 const deployDockerComposeLabel = "aws.ecs.fargate.deploy"
@@ -50,7 +49,6 @@ fargate service deploy -r 37
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceDeployOperation{
 			ServiceName: getServiceName(),
-			Task:        getTaskName(),
 			Region:      region,
 			Image:       flagServiceDeployImage,
 			ComposeFile: flagServiceDeployDockerComposeFile,
@@ -132,12 +130,13 @@ func deployRevision(operation *ServiceDeployOperation) {
 
 	//build full task definiton arn with revision
 	revisionNumber := ecs.ResolveRevisionNumber(service.TaskDefinitionArn, operation.Revision)
+	taskFamily := ecs.GetTaskFamily(service.TaskDefinitionArn)
 
 	if revisionNumber == "" {
 		console.IssueExit("Could not resolve revision number")
 	}
 
-	taskDefinitionArn := ecs.GetTaskDefinitionARN(operation.Region, account, operation.Task, revisionNumber)
+	taskDefinitionArn := ecs.GetTaskDefinitionARN(operation.Region, account, taskFamily, revisionNumber)
 
 	ecs.UpdateServiceTaskDefinition(operation.ServiceName, taskDefinitionArn)
 

--- a/ecs/task_definition.go
+++ b/ecs/task_definition.go
@@ -286,6 +286,12 @@ func (ecs *ECS) GetTaskDefinitionARN(region string, account string, family strin
 	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:%s", region, account, family, revisionNumber)
 }
 
+//GetTaskFamily returns the task family from a task definition ARN
+func (ecs *ECS) GetTaskFamily(taskDefinitionArn string) string {
+	contents := strings.Split(taskDefinitionArn, ":")
+	return strings.TrimPrefix(contents[len(contents)-2], "task-definition/")
+}
+
 //GetCpuAndMemoryFromTaskDefinition returns the cpu/memory from a task definition
 func (ecs *ECS) GetCpuAndMemoryFromTaskDefinition(taskDefinitionArn string) (string, string) {
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)

--- a/ecs/task_definition_test.go
+++ b/ecs/task_definition_test.go
@@ -1,0 +1,74 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+func TestResolveRevisionNumber_Absolute(t *testing.T) {
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:25"
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "12") != "12" {
+		t.Error("Expected 12")
+	}
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "37") != "37" {
+		t.Error("Expected 37")
+	}
+}
+
+func TestResolveRevisionNumber_NegativeExpression(t *testing.T) {
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:50"
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "-1") != "49" {
+		t.Error("Expected 49")
+	}
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "-10") != "40" {
+		t.Error("Expected 40")
+	}
+}
+func TestResolveRevisionNumber_PositiveExpression(t *testing.T) {
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:20"
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "+1") != "21" {
+		t.Error("Expected 21")
+	}
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "+33") != "53" {
+		t.Error("Expected 53")
+	}
+}
+func TestResolveRevisionNumber_NoInput(t *testing.T) {
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+
+	if ecs.ResolveRevisionNumber("arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:5", "") != "5" {
+		t.Error("Expected 5")
+	}
+
+	if ecs.ResolveRevisionNumber("arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:12", "") != "12" {
+		t.Error("Expected 12")
+	}
+
+}
+func TestResolveRevisionNumber_InvalidInput(t *testing.T) {
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:2"
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "q") != "" {
+		t.Error("Expected empty string")
+	}
+
+	if ecs.ResolveRevisionNumber(taskDefinitionArn, "-10") != "" {
+		t.Error("Expected empty string")
+	}
+}

--- a/ecs/task_definition_test.go
+++ b/ecs/task_definition_test.go
@@ -6,6 +6,25 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+func TestGetTaskFamily(t *testing.T) {
+	var got, expected string
+
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+
+	got = ecs.GetTaskFamily("arn:aws:ecs:us-east-1:000000000000:task-definition/my-app-dev:25")
+	expected = "my-app-dev"
+	if got != expected {
+		t.Errorf("Expected %s, got %s", expected, got)
+	}
+
+	got = ecs.GetTaskFamily("arn:aws:ecs:us-east-1:000000000000:task-definition/app-prod:2")
+	expected = "app-prod"
+	if got != expected {
+		t.Errorf("Expected %s, got %s", expected, got)
+	}
+}
+
 func TestResolveRevisionNumber_Absolute(t *testing.T) {
 	sess := session.Must(session.NewSession())
 	ecs := New(sess, "my-app-dev")


### PR DESCRIPTION
Allows deploying a task definition revision to a service.

Closes #28 

```
Deploy applications to services

The Docker container image to use in the service can be specified
via the --image flag.

The docker-compose.yml format is also supported using the --file flag.
If -f is specified, the image and the environment variables in the
docker-compose.yml file will be deployed.

A task definition revision can be specified via the --revision flag.
The revision number can either be absolute or a delta specified with a sign
such as +5 or -2, where -2 is "2 configurations ago" from the current
deployed revision.

Usage:
  fargate service deploy [flags]

Examples:

fargate service deploy -i 123456789.dkr.ecr.us-east-1.amazonaws.com/my-service:1.0
fargate service deploy -f docker-compose.yml
fargate service deploy -r 37


Flags:
  -f, --file string       Specify a docker-compose.yml file to deploy. The image and environment variables in the file will be deployed.
  -h, --help              help for deploy
  -i, --image string      Docker image to run in the service
      --image-only        Only deploy the image when a docker-compose.yml file is specified.
  -r, --revision string   Task definition revision number

Global Flags:
  -c, --cluster string   ECS cluster name
      --no-emoji         Disable emoji output
      --nocolor          Disable color output
      --region string    AWS region (default "us-east-1")
  -s, --service string   ECS service name
  -v, --verbose          Verbose output
```