### PR TITLE
Sort env vars output by key

### DIFF
--- a/cmd/service_env_list.go
+++ b/cmd/service_env_list.go
@@ -31,6 +31,8 @@ func serviceEnvList(operation *ServiceEnvListOperation) {
 	service := ecs.DescribeService(operation.ServiceName)
 	envVars := ecs.GetEnvVarsFromTaskDefinition(service.TaskDefinitionArn)
 
+	ecs.SortEnvVars(envVars)
+
 	for _, envVar := range envVars {
 		fmt.Printf("%s=%s\n", envVar.Key, envVar.Value)
 	}

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -118,6 +118,8 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 	if len(service.EnvVars) > 0 {
 		console.KeyValue("Environment Variables", "\n")
 
+		ecs.SortEnvVars(service.EnvVars)
+
 		for _, envVar := range service.EnvVars {
 			fmt.Printf("   %s=%s\n", envVar.Key, envVar.Value)
 		}

--- a/ecs/task_definition.go
+++ b/ecs/task_definition.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -31,6 +32,18 @@ type CreateTaskDefinitionInput struct {
 type EnvVar struct {
 	Key   string
 	Value string
+}
+
+type envSorter []EnvVar
+
+func (a envSorter) Len() int {
+	return len(a)
+}
+func (a envSorter) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+func (a envSorter) Less(i, j int) bool {
+	return a[i].Key < a[j].Key
 }
 
 func (ecs *ECS) CreateTaskDefinition(input *CreateTaskDefinitionInput) string {
@@ -338,4 +351,10 @@ func (ecs *ECS) ResolveRevisionNumber(taskDefinitionArn string, revisionExpressi
 	result := strconv.FormatInt(nextRevisionNumber, 10)
 
 	return result
+}
+
+// SortEnvVars sorts a slice of EnvVar's by Key
+func (ecs *ECS) SortEnvVars(envVars []EnvVar) []EnvVar {
+	sort.Sort(envSorter(envVars))
+	return envVars
 }

--- a/ecs/task_definition_test.go
+++ b/ecs/task_definition_test.go
@@ -6,6 +6,36 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+func TestSortEnvVars(t *testing.T) {
+	sess := session.Must(session.NewSession())
+	ecs := New(sess, "my-app-dev")
+
+	result := ecs.SortEnvVars([]EnvVar{
+		EnvVar{Key: "PORT", Value: "8080"},
+		EnvVar{Key: "ENVIRONMENT", Value: "prod"},
+		EnvVar{Key: "PRODUCT", Value: "my-app-prod"},
+		EnvVar{Key: "ENABLE_LOGGING", Value: "false"},
+		EnvVar{Key: "HEALTHCHECK", Value: "/hc"},
+	})
+
+	sorted := []EnvVar{
+		EnvVar{Key: "ENABLE_LOGGING", Value: "false"},
+		EnvVar{Key: "ENVIRONMENT", Value: "prod"},
+		EnvVar{Key: "HEALTHCHECK", Value: "/hc"},
+		EnvVar{Key: "PORT", Value: "8080"},
+		EnvVar{Key: "PRODUCT", Value: "my-app-prod"},
+	}
+
+	for i, env := range result {
+		expected := sorted[i].Key
+		got := env.Key
+
+		if got != expected {
+			t.Errorf("Expected %s, got %s", expected, got)
+		}
+	}
+}
+
 func TestGetTaskFamily(t *testing.T) {
 	var got, expected string
 


### PR DESCRIPTION
Sorts the output of env vars in `service info` and `service env list` by Key.

```
$ fargate service env list

ENABLE_LOGGING=false
ENVIRONMENT=dev
HEALTHCHECK=/hc
PORT=3000
PRODUCT=my-app-dev
```