### PR TITLE
Bump aws-sdk-go revision to 1.15.77 (Closes #37)

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.15.68"
+  version = "1.15.77"
 
 [[constraint]]
   name = "github.com/golang/mock"


### PR DESCRIPTION
Update `aws-sdk-go` revision to 1.15.77, which is the first release to support `Secrets` in the `ContainerDefinition` model:

```golang
// The secrets to pass to the container.
Secrets []*Secret `locationName:"secrets" type:"list"`
```

This should close #37.