### PR TITLE
dep ensure + make mocks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,51 +3,9 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/csm",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/ini",
-    "internal/sdkio",
-    "internal/sdkrand",
-    "internal/sdkuri",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/ec2query",
-    "private/protocol/json/jsonutil",
-    "private/protocol/jsonrpc",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/xml/xmlutil",
-    "service/acm",
-    "service/acm/acmiface",
-    "service/cloudwatchevents",
-    "service/cloudwatchlogs",
-    "service/ec2",
-    "service/ec2/ec2iface",
-    "service/ecs",
-    "service/elbv2",
-    "service/elbv2/elbv2iface",
-    "service/servicediscovery",
-    "service/sts"
-  ]
-  revision = "3264db248fe8d241f6949ed35e33b11c0aec3c93"
-  version = "v1.15.68"
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/processcreds","aws/credentials/stscreds","aws/csm","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/ini","internal/sdkio","internal/sdkrand","internal/sdkuri","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/acm","service/acm/acmiface","service/cloudwatchevents","service/cloudwatchlogs","service/ec2","service/ec2/ec2iface","service/ecs","service/elbv2","service/elbv2/elbv2iface","service/servicediscovery","service/sts"]
+  revision = "c1afd6c3340feedd0a2c1cd929dcb291d4bd09ba"
+  version = "v1.16.23"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -62,27 +20,13 @@
 
 [[projects]]
   name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
+  packages = [".","simplelru"]
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
   name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/printer",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token"
-  ]
+  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
@@ -95,7 +39,7 @@
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [[projects]]
   name = "github.com/kyokomi/emoji"
@@ -141,10 +85,7 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem"
-  ]
+  packages = [".","mem"]
   revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
   version = "v1.1.2"
 
@@ -192,22 +133,12 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows"
-  ]
+  packages = ["unix","windows"]
   revision = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "internal/gen",
-    "internal/triegen",
-    "internal/ucd",
-    "transform",
-    "unicode/cldr",
-    "unicode/norm"
-  ]
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
@@ -220,6 +151,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "407369f0897adbe1d594fa6638337232d427d78d7b9fe7797883e225516348eb"
+  inputs-digest = "7cf65c122c3d47f444111108634964ee3e6d0054c7bd0ccc6ec0f9de4a06edf6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ec2/mock/sdk/ec2iface.go
+++ b/ec2/mock/sdk/ec2iface.go
@@ -79,6 +79,50 @@ func (mr *MockEC2APIMockRecorder) AcceptReservedInstancesExchangeQuoteRequest(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptReservedInstancesExchangeQuoteRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptReservedInstancesExchangeQuoteRequest), arg0)
 }
 
+// AcceptTransitGatewayVpcAttachment mocks base method
+func (m *MockEC2API) AcceptTransitGatewayVpcAttachment(arg0 *ec2.AcceptTransitGatewayVpcAttachmentInput) (*ec2.AcceptTransitGatewayVpcAttachmentOutput, error) {
+	ret := m.ctrl.Call(m, "AcceptTransitGatewayVpcAttachment", arg0)
+	ret0, _ := ret[0].(*ec2.AcceptTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AcceptTransitGatewayVpcAttachment indicates an expected call of AcceptTransitGatewayVpcAttachment
+func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayVpcAttachment), arg0)
+}
+
+// AcceptTransitGatewayVpcAttachmentWithContext mocks base method
+func (m *MockEC2API) AcceptTransitGatewayVpcAttachmentWithContext(arg0 aws.Context, arg1 *ec2.AcceptTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.AcceptTransitGatewayVpcAttachmentOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AcceptTransitGatewayVpcAttachmentWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AcceptTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AcceptTransitGatewayVpcAttachmentWithContext indicates an expected call of AcceptTransitGatewayVpcAttachmentWithContext
+func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayVpcAttachmentWithContext), varargs...)
+}
+
+// AcceptTransitGatewayVpcAttachmentRequest mocks base method
+func (m *MockEC2API) AcceptTransitGatewayVpcAttachmentRequest(arg0 *ec2.AcceptTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.AcceptTransitGatewayVpcAttachmentOutput) {
+	ret := m.ctrl.Call(m, "AcceptTransitGatewayVpcAttachmentRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AcceptTransitGatewayVpcAttachmentOutput)
+	return ret0, ret1
+}
+
+// AcceptTransitGatewayVpcAttachmentRequest indicates an expected call of AcceptTransitGatewayVpcAttachmentRequest
+func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayVpcAttachmentRequest), arg0)
+}
+
 // AcceptVpcEndpointConnections mocks base method
 func (m *MockEC2API) AcceptVpcEndpointConnections(arg0 *ec2.AcceptVpcEndpointConnectionsInput) (*ec2.AcceptVpcEndpointConnectionsOutput, error) {
 	ret := m.ctrl.Call(m, "AcceptVpcEndpointConnections", arg0)
@@ -299,6 +343,50 @@ func (mr *MockEC2APIMockRecorder) AllocateHostsRequest(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateHostsRequest", reflect.TypeOf((*MockEC2API)(nil).AllocateHostsRequest), arg0)
 }
 
+// ApplySecurityGroupsToClientVpnTargetNetwork mocks base method
+func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetwork(arg0 *ec2.ApplySecurityGroupsToClientVpnTargetNetworkInput) (*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput, error) {
+	ret := m.ctrl.Call(m, "ApplySecurityGroupsToClientVpnTargetNetwork", arg0)
+	ret0, _ := ret[0].(*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplySecurityGroupsToClientVpnTargetNetwork indicates an expected call of ApplySecurityGroupsToClientVpnTargetNetwork
+func (mr *MockEC2APIMockRecorder) ApplySecurityGroupsToClientVpnTargetNetwork(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySecurityGroupsToClientVpnTargetNetwork", reflect.TypeOf((*MockEC2API)(nil).ApplySecurityGroupsToClientVpnTargetNetwork), arg0)
+}
+
+// ApplySecurityGroupsToClientVpnTargetNetworkWithContext mocks base method
+func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetworkWithContext(arg0 aws.Context, arg1 *ec2.ApplySecurityGroupsToClientVpnTargetNetworkInput, arg2 ...request.Option) (*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ApplySecurityGroupsToClientVpnTargetNetworkWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplySecurityGroupsToClientVpnTargetNetworkWithContext indicates an expected call of ApplySecurityGroupsToClientVpnTargetNetworkWithContext
+func (mr *MockEC2APIMockRecorder) ApplySecurityGroupsToClientVpnTargetNetworkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySecurityGroupsToClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).ApplySecurityGroupsToClientVpnTargetNetworkWithContext), varargs...)
+}
+
+// ApplySecurityGroupsToClientVpnTargetNetworkRequest mocks base method
+func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetworkRequest(arg0 *ec2.ApplySecurityGroupsToClientVpnTargetNetworkInput) (*request.Request, *ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput) {
+	ret := m.ctrl.Call(m, "ApplySecurityGroupsToClientVpnTargetNetworkRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput)
+	return ret0, ret1
+}
+
+// ApplySecurityGroupsToClientVpnTargetNetworkRequest indicates an expected call of ApplySecurityGroupsToClientVpnTargetNetworkRequest
+func (mr *MockEC2APIMockRecorder) ApplySecurityGroupsToClientVpnTargetNetworkRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySecurityGroupsToClientVpnTargetNetworkRequest", reflect.TypeOf((*MockEC2API)(nil).ApplySecurityGroupsToClientVpnTargetNetworkRequest), arg0)
+}
+
 // AssignIpv6Addresses mocks base method
 func (m *MockEC2API) AssignIpv6Addresses(arg0 *ec2.AssignIpv6AddressesInput) (*ec2.AssignIpv6AddressesOutput, error) {
 	ret := m.ctrl.Call(m, "AssignIpv6Addresses", arg0)
@@ -429,6 +517,50 @@ func (m *MockEC2API) AssociateAddressRequest(arg0 *ec2.AssociateAddressInput) (*
 // AssociateAddressRequest indicates an expected call of AssociateAddressRequest
 func (mr *MockEC2APIMockRecorder) AssociateAddressRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateAddressRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateAddressRequest), arg0)
+}
+
+// AssociateClientVpnTargetNetwork mocks base method
+func (m *MockEC2API) AssociateClientVpnTargetNetwork(arg0 *ec2.AssociateClientVpnTargetNetworkInput) (*ec2.AssociateClientVpnTargetNetworkOutput, error) {
+	ret := m.ctrl.Call(m, "AssociateClientVpnTargetNetwork", arg0)
+	ret0, _ := ret[0].(*ec2.AssociateClientVpnTargetNetworkOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateClientVpnTargetNetwork indicates an expected call of AssociateClientVpnTargetNetwork
+func (mr *MockEC2APIMockRecorder) AssociateClientVpnTargetNetwork(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateClientVpnTargetNetwork", reflect.TypeOf((*MockEC2API)(nil).AssociateClientVpnTargetNetwork), arg0)
+}
+
+// AssociateClientVpnTargetNetworkWithContext mocks base method
+func (m *MockEC2API) AssociateClientVpnTargetNetworkWithContext(arg0 aws.Context, arg1 *ec2.AssociateClientVpnTargetNetworkInput, arg2 ...request.Option) (*ec2.AssociateClientVpnTargetNetworkOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AssociateClientVpnTargetNetworkWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AssociateClientVpnTargetNetworkOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateClientVpnTargetNetworkWithContext indicates an expected call of AssociateClientVpnTargetNetworkWithContext
+func (mr *MockEC2APIMockRecorder) AssociateClientVpnTargetNetworkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateClientVpnTargetNetworkWithContext), varargs...)
+}
+
+// AssociateClientVpnTargetNetworkRequest mocks base method
+func (m *MockEC2API) AssociateClientVpnTargetNetworkRequest(arg0 *ec2.AssociateClientVpnTargetNetworkInput) (*request.Request, *ec2.AssociateClientVpnTargetNetworkOutput) {
+	ret := m.ctrl.Call(m, "AssociateClientVpnTargetNetworkRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateClientVpnTargetNetworkOutput)
+	return ret0, ret1
+}
+
+// AssociateClientVpnTargetNetworkRequest indicates an expected call of AssociateClientVpnTargetNetworkRequest
+func (mr *MockEC2APIMockRecorder) AssociateClientVpnTargetNetworkRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateClientVpnTargetNetworkRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateClientVpnTargetNetworkRequest), arg0)
 }
 
 // AssociateDhcpOptions mocks base method
@@ -605,6 +737,50 @@ func (m *MockEC2API) AssociateSubnetCidrBlockRequest(arg0 *ec2.AssociateSubnetCi
 // AssociateSubnetCidrBlockRequest indicates an expected call of AssociateSubnetCidrBlockRequest
 func (mr *MockEC2APIMockRecorder) AssociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateSubnetCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateSubnetCidrBlockRequest), arg0)
+}
+
+// AssociateTransitGatewayRouteTable mocks base method
+func (m *MockEC2API) AssociateTransitGatewayRouteTable(arg0 *ec2.AssociateTransitGatewayRouteTableInput) (*ec2.AssociateTransitGatewayRouteTableOutput, error) {
+	ret := m.ctrl.Call(m, "AssociateTransitGatewayRouteTable", arg0)
+	ret0, _ := ret[0].(*ec2.AssociateTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateTransitGatewayRouteTable indicates an expected call of AssociateTransitGatewayRouteTable
+func (mr *MockEC2APIMockRecorder) AssociateTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).AssociateTransitGatewayRouteTable), arg0)
+}
+
+// AssociateTransitGatewayRouteTableWithContext mocks base method
+func (m *MockEC2API) AssociateTransitGatewayRouteTableWithContext(arg0 aws.Context, arg1 *ec2.AssociateTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.AssociateTransitGatewayRouteTableOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AssociateTransitGatewayRouteTableWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AssociateTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateTransitGatewayRouteTableWithContext indicates an expected call of AssociateTransitGatewayRouteTableWithContext
+func (mr *MockEC2APIMockRecorder) AssociateTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateTransitGatewayRouteTableWithContext), varargs...)
+}
+
+// AssociateTransitGatewayRouteTableRequest mocks base method
+func (m *MockEC2API) AssociateTransitGatewayRouteTableRequest(arg0 *ec2.AssociateTransitGatewayRouteTableInput) (*request.Request, *ec2.AssociateTransitGatewayRouteTableOutput) {
+	ret := m.ctrl.Call(m, "AssociateTransitGatewayRouteTableRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateTransitGatewayRouteTableOutput)
+	return ret0, ret1
+}
+
+// AssociateTransitGatewayRouteTableRequest indicates an expected call of AssociateTransitGatewayRouteTableRequest
+func (mr *MockEC2APIMockRecorder) AssociateTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateTransitGatewayRouteTableRequest), arg0)
 }
 
 // AssociateVpcCidrBlock mocks base method
@@ -869,6 +1045,50 @@ func (m *MockEC2API) AttachVpnGatewayRequest(arg0 *ec2.AttachVpnGatewayInput) (*
 // AttachVpnGatewayRequest indicates an expected call of AttachVpnGatewayRequest
 func (mr *MockEC2APIMockRecorder) AttachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).AttachVpnGatewayRequest), arg0)
+}
+
+// AuthorizeClientVpnIngress mocks base method
+func (m *MockEC2API) AuthorizeClientVpnIngress(arg0 *ec2.AuthorizeClientVpnIngressInput) (*ec2.AuthorizeClientVpnIngressOutput, error) {
+	ret := m.ctrl.Call(m, "AuthorizeClientVpnIngress", arg0)
+	ret0, _ := ret[0].(*ec2.AuthorizeClientVpnIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthorizeClientVpnIngress indicates an expected call of AuthorizeClientVpnIngress
+func (mr *MockEC2APIMockRecorder) AuthorizeClientVpnIngress(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeClientVpnIngress", reflect.TypeOf((*MockEC2API)(nil).AuthorizeClientVpnIngress), arg0)
+}
+
+// AuthorizeClientVpnIngressWithContext mocks base method
+func (m *MockEC2API) AuthorizeClientVpnIngressWithContext(arg0 aws.Context, arg1 *ec2.AuthorizeClientVpnIngressInput, arg2 ...request.Option) (*ec2.AuthorizeClientVpnIngressOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AuthorizeClientVpnIngressWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AuthorizeClientVpnIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthorizeClientVpnIngressWithContext indicates an expected call of AuthorizeClientVpnIngressWithContext
+func (mr *MockEC2APIMockRecorder) AuthorizeClientVpnIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeClientVpnIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).AuthorizeClientVpnIngressWithContext), varargs...)
+}
+
+// AuthorizeClientVpnIngressRequest mocks base method
+func (m *MockEC2API) AuthorizeClientVpnIngressRequest(arg0 *ec2.AuthorizeClientVpnIngressInput) (*request.Request, *ec2.AuthorizeClientVpnIngressOutput) {
+	ret := m.ctrl.Call(m, "AuthorizeClientVpnIngressRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AuthorizeClientVpnIngressOutput)
+	return ret0, ret1
+}
+
+// AuthorizeClientVpnIngressRequest indicates an expected call of AuthorizeClientVpnIngressRequest
+func (mr *MockEC2APIMockRecorder) AuthorizeClientVpnIngressRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeClientVpnIngressRequest", reflect.TypeOf((*MockEC2API)(nil).AuthorizeClientVpnIngressRequest), arg0)
 }
 
 // AuthorizeSecurityGroupEgress mocks base method
@@ -1573,6 +1793,94 @@ func (m *MockEC2API) CreateCapacityReservationRequest(arg0 *ec2.CreateCapacityRe
 // CreateCapacityReservationRequest indicates an expected call of CreateCapacityReservationRequest
 func (mr *MockEC2APIMockRecorder) CreateCapacityReservationRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationRequest), arg0)
+}
+
+// CreateClientVpnEndpoint mocks base method
+func (m *MockEC2API) CreateClientVpnEndpoint(arg0 *ec2.CreateClientVpnEndpointInput) (*ec2.CreateClientVpnEndpointOutput, error) {
+	ret := m.ctrl.Call(m, "CreateClientVpnEndpoint", arg0)
+	ret0, _ := ret[0].(*ec2.CreateClientVpnEndpointOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateClientVpnEndpoint indicates an expected call of CreateClientVpnEndpoint
+func (mr *MockEC2APIMockRecorder) CreateClientVpnEndpoint(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnEndpoint", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnEndpoint), arg0)
+}
+
+// CreateClientVpnEndpointWithContext mocks base method
+func (m *MockEC2API) CreateClientVpnEndpointWithContext(arg0 aws.Context, arg1 *ec2.CreateClientVpnEndpointInput, arg2 ...request.Option) (*ec2.CreateClientVpnEndpointOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateClientVpnEndpointWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateClientVpnEndpointOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateClientVpnEndpointWithContext indicates an expected call of CreateClientVpnEndpointWithContext
+func (mr *MockEC2APIMockRecorder) CreateClientVpnEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnEndpointWithContext), varargs...)
+}
+
+// CreateClientVpnEndpointRequest mocks base method
+func (m *MockEC2API) CreateClientVpnEndpointRequest(arg0 *ec2.CreateClientVpnEndpointInput) (*request.Request, *ec2.CreateClientVpnEndpointOutput) {
+	ret := m.ctrl.Call(m, "CreateClientVpnEndpointRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateClientVpnEndpointOutput)
+	return ret0, ret1
+}
+
+// CreateClientVpnEndpointRequest indicates an expected call of CreateClientVpnEndpointRequest
+func (mr *MockEC2APIMockRecorder) CreateClientVpnEndpointRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnEndpointRequest), arg0)
+}
+
+// CreateClientVpnRoute mocks base method
+func (m *MockEC2API) CreateClientVpnRoute(arg0 *ec2.CreateClientVpnRouteInput) (*ec2.CreateClientVpnRouteOutput, error) {
+	ret := m.ctrl.Call(m, "CreateClientVpnRoute", arg0)
+	ret0, _ := ret[0].(*ec2.CreateClientVpnRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateClientVpnRoute indicates an expected call of CreateClientVpnRoute
+func (mr *MockEC2APIMockRecorder) CreateClientVpnRoute(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnRoute", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnRoute), arg0)
+}
+
+// CreateClientVpnRouteWithContext mocks base method
+func (m *MockEC2API) CreateClientVpnRouteWithContext(arg0 aws.Context, arg1 *ec2.CreateClientVpnRouteInput, arg2 ...request.Option) (*ec2.CreateClientVpnRouteOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateClientVpnRouteWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateClientVpnRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateClientVpnRouteWithContext indicates an expected call of CreateClientVpnRouteWithContext
+func (mr *MockEC2APIMockRecorder) CreateClientVpnRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnRouteWithContext), varargs...)
+}
+
+// CreateClientVpnRouteRequest mocks base method
+func (m *MockEC2API) CreateClientVpnRouteRequest(arg0 *ec2.CreateClientVpnRouteInput) (*request.Request, *ec2.CreateClientVpnRouteOutput) {
+	ret := m.ctrl.Call(m, "CreateClientVpnRouteRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateClientVpnRouteOutput)
+	return ret0, ret1
+}
+
+// CreateClientVpnRouteRequest indicates an expected call of CreateClientVpnRouteRequest
+func (mr *MockEC2APIMockRecorder) CreateClientVpnRouteRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnRouteRequest", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnRouteRequest), arg0)
 }
 
 // CreateCustomerGateway mocks base method
@@ -2807,6 +3115,182 @@ func (mr *MockEC2APIMockRecorder) CreateTagsRequest(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTagsRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTagsRequest), arg0)
 }
 
+// CreateTransitGateway mocks base method
+func (m *MockEC2API) CreateTransitGateway(arg0 *ec2.CreateTransitGatewayInput) (*ec2.CreateTransitGatewayOutput, error) {
+	ret := m.ctrl.Call(m, "CreateTransitGateway", arg0)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGateway indicates an expected call of CreateTransitGateway
+func (mr *MockEC2APIMockRecorder) CreateTransitGateway(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGateway", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGateway), arg0)
+}
+
+// CreateTransitGatewayWithContext mocks base method
+func (m *MockEC2API) CreateTransitGatewayWithContext(arg0 aws.Context, arg1 *ec2.CreateTransitGatewayInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTransitGatewayWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayWithContext indicates an expected call of CreateTransitGatewayWithContext
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayWithContext), varargs...)
+}
+
+// CreateTransitGatewayRequest mocks base method
+func (m *MockEC2API) CreateTransitGatewayRequest(arg0 *ec2.CreateTransitGatewayInput) (*request.Request, *ec2.CreateTransitGatewayOutput) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTransitGatewayOutput)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRequest indicates an expected call of CreateTransitGatewayRequest
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRequest), arg0)
+}
+
+// CreateTransitGatewayRoute mocks base method
+func (m *MockEC2API) CreateTransitGatewayRoute(arg0 *ec2.CreateTransitGatewayRouteInput) (*ec2.CreateTransitGatewayRouteOutput, error) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRoute", arg0)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRoute indicates an expected call of CreateTransitGatewayRoute
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRoute(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRoute", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRoute), arg0)
+}
+
+// CreateTransitGatewayRouteWithContext mocks base method
+func (m *MockEC2API) CreateTransitGatewayRouteWithContext(arg0 aws.Context, arg1 *ec2.CreateTransitGatewayRouteInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayRouteOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRouteWithContext indicates an expected call of CreateTransitGatewayRouteWithContext
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteWithContext), varargs...)
+}
+
+// CreateTransitGatewayRouteRequest mocks base method
+func (m *MockEC2API) CreateTransitGatewayRouteRequest(arg0 *ec2.CreateTransitGatewayRouteInput) (*request.Request, *ec2.CreateTransitGatewayRouteOutput) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTransitGatewayRouteOutput)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRouteRequest indicates an expected call of CreateTransitGatewayRouteRequest
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteRequest), arg0)
+}
+
+// CreateTransitGatewayRouteTable mocks base method
+func (m *MockEC2API) CreateTransitGatewayRouteTable(arg0 *ec2.CreateTransitGatewayRouteTableInput) (*ec2.CreateTransitGatewayRouteTableOutput, error) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteTable", arg0)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRouteTable indicates an expected call of CreateTransitGatewayRouteTable
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteTable), arg0)
+}
+
+// CreateTransitGatewayRouteTableWithContext mocks base method
+func (m *MockEC2API) CreateTransitGatewayRouteTableWithContext(arg0 aws.Context, arg1 *ec2.CreateTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayRouteTableOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteTableWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRouteTableWithContext indicates an expected call of CreateTransitGatewayRouteTableWithContext
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteTableWithContext), varargs...)
+}
+
+// CreateTransitGatewayRouteTableRequest mocks base method
+func (m *MockEC2API) CreateTransitGatewayRouteTableRequest(arg0 *ec2.CreateTransitGatewayRouteTableInput) (*request.Request, *ec2.CreateTransitGatewayRouteTableOutput) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteTableRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTransitGatewayRouteTableOutput)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayRouteTableRequest indicates an expected call of CreateTransitGatewayRouteTableRequest
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteTableRequest), arg0)
+}
+
+// CreateTransitGatewayVpcAttachment mocks base method
+func (m *MockEC2API) CreateTransitGatewayVpcAttachment(arg0 *ec2.CreateTransitGatewayVpcAttachmentInput) (*ec2.CreateTransitGatewayVpcAttachmentOutput, error) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayVpcAttachment", arg0)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayVpcAttachment indicates an expected call of CreateTransitGatewayVpcAttachment
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayVpcAttachment), arg0)
+}
+
+// CreateTransitGatewayVpcAttachmentWithContext mocks base method
+func (m *MockEC2API) CreateTransitGatewayVpcAttachmentWithContext(arg0 aws.Context, arg1 *ec2.CreateTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayVpcAttachmentOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTransitGatewayVpcAttachmentWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayVpcAttachmentWithContext indicates an expected call of CreateTransitGatewayVpcAttachmentWithContext
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayVpcAttachmentWithContext), varargs...)
+}
+
+// CreateTransitGatewayVpcAttachmentRequest mocks base method
+func (m *MockEC2API) CreateTransitGatewayVpcAttachmentRequest(arg0 *ec2.CreateTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.CreateTransitGatewayVpcAttachmentOutput) {
+	ret := m.ctrl.Call(m, "CreateTransitGatewayVpcAttachmentRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTransitGatewayVpcAttachmentOutput)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayVpcAttachmentRequest indicates an expected call of CreateTransitGatewayVpcAttachmentRequest
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayVpcAttachmentRequest), arg0)
+}
+
 // CreateVolume mocks base method
 func (m *MockEC2API) CreateVolume(arg0 *ec2.CreateVolumeInput) (*ec2.Volume, error) {
 	ret := m.ctrl.Call(m, "CreateVolume", arg0)
@@ -3201,6 +3685,94 @@ func (m *MockEC2API) CreateVpnGatewayRequest(arg0 *ec2.CreateVpnGatewayInput) (*
 // CreateVpnGatewayRequest indicates an expected call of CreateVpnGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateVpnGatewayRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpnGatewayRequest), arg0)
+}
+
+// DeleteClientVpnEndpoint mocks base method
+func (m *MockEC2API) DeleteClientVpnEndpoint(arg0 *ec2.DeleteClientVpnEndpointInput) (*ec2.DeleteClientVpnEndpointOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteClientVpnEndpoint", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteClientVpnEndpointOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteClientVpnEndpoint indicates an expected call of DeleteClientVpnEndpoint
+func (mr *MockEC2APIMockRecorder) DeleteClientVpnEndpoint(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnEndpoint", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnEndpoint), arg0)
+}
+
+// DeleteClientVpnEndpointWithContext mocks base method
+func (m *MockEC2API) DeleteClientVpnEndpointWithContext(arg0 aws.Context, arg1 *ec2.DeleteClientVpnEndpointInput, arg2 ...request.Option) (*ec2.DeleteClientVpnEndpointOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteClientVpnEndpointWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteClientVpnEndpointOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteClientVpnEndpointWithContext indicates an expected call of DeleteClientVpnEndpointWithContext
+func (mr *MockEC2APIMockRecorder) DeleteClientVpnEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnEndpointWithContext), varargs...)
+}
+
+// DeleteClientVpnEndpointRequest mocks base method
+func (m *MockEC2API) DeleteClientVpnEndpointRequest(arg0 *ec2.DeleteClientVpnEndpointInput) (*request.Request, *ec2.DeleteClientVpnEndpointOutput) {
+	ret := m.ctrl.Call(m, "DeleteClientVpnEndpointRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteClientVpnEndpointOutput)
+	return ret0, ret1
+}
+
+// DeleteClientVpnEndpointRequest indicates an expected call of DeleteClientVpnEndpointRequest
+func (mr *MockEC2APIMockRecorder) DeleteClientVpnEndpointRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnEndpointRequest), arg0)
+}
+
+// DeleteClientVpnRoute mocks base method
+func (m *MockEC2API) DeleteClientVpnRoute(arg0 *ec2.DeleteClientVpnRouteInput) (*ec2.DeleteClientVpnRouteOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteClientVpnRoute", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteClientVpnRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteClientVpnRoute indicates an expected call of DeleteClientVpnRoute
+func (mr *MockEC2APIMockRecorder) DeleteClientVpnRoute(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnRoute", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnRoute), arg0)
+}
+
+// DeleteClientVpnRouteWithContext mocks base method
+func (m *MockEC2API) DeleteClientVpnRouteWithContext(arg0 aws.Context, arg1 *ec2.DeleteClientVpnRouteInput, arg2 ...request.Option) (*ec2.DeleteClientVpnRouteOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteClientVpnRouteWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteClientVpnRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteClientVpnRouteWithContext indicates an expected call of DeleteClientVpnRouteWithContext
+func (mr *MockEC2APIMockRecorder) DeleteClientVpnRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnRouteWithContext), varargs...)
+}
+
+// DeleteClientVpnRouteRequest mocks base method
+func (m *MockEC2API) DeleteClientVpnRouteRequest(arg0 *ec2.DeleteClientVpnRouteInput) (*request.Request, *ec2.DeleteClientVpnRouteOutput) {
+	ret := m.ctrl.Call(m, "DeleteClientVpnRouteRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteClientVpnRouteOutput)
+	return ret0, ret1
+}
+
+// DeleteClientVpnRouteRequest indicates an expected call of DeleteClientVpnRouteRequest
+func (mr *MockEC2APIMockRecorder) DeleteClientVpnRouteRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnRouteRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnRouteRequest), arg0)
 }
 
 // DeleteCustomerGateway mocks base method
@@ -4215,6 +4787,182 @@ func (mr *MockEC2APIMockRecorder) DeleteTagsRequest(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTagsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTagsRequest), arg0)
 }
 
+// DeleteTransitGateway mocks base method
+func (m *MockEC2API) DeleteTransitGateway(arg0 *ec2.DeleteTransitGatewayInput) (*ec2.DeleteTransitGatewayOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteTransitGateway", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGateway indicates an expected call of DeleteTransitGateway
+func (mr *MockEC2APIMockRecorder) DeleteTransitGateway(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGateway), arg0)
+}
+
+// DeleteTransitGatewayWithContext mocks base method
+func (m *MockEC2API) DeleteTransitGatewayWithContext(arg0 aws.Context, arg1 *ec2.DeleteTransitGatewayInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayWithContext indicates an expected call of DeleteTransitGatewayWithContext
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayWithContext), varargs...)
+}
+
+// DeleteTransitGatewayRequest mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRequest(arg0 *ec2.DeleteTransitGatewayInput) (*request.Request, *ec2.DeleteTransitGatewayOutput) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayOutput)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRequest indicates an expected call of DeleteTransitGatewayRequest
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRequest), arg0)
+}
+
+// DeleteTransitGatewayRoute mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRoute(arg0 *ec2.DeleteTransitGatewayRouteInput) (*ec2.DeleteTransitGatewayRouteOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRoute", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRoute indicates an expected call of DeleteTransitGatewayRoute
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRoute(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRoute", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRoute), arg0)
+}
+
+// DeleteTransitGatewayRouteWithContext mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRouteWithContext(arg0 aws.Context, arg1 *ec2.DeleteTransitGatewayRouteInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayRouteOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRouteWithContext indicates an expected call of DeleteTransitGatewayRouteWithContext
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteWithContext), varargs...)
+}
+
+// DeleteTransitGatewayRouteRequest mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRouteRequest(arg0 *ec2.DeleteTransitGatewayRouteInput) (*request.Request, *ec2.DeleteTransitGatewayRouteOutput) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayRouteOutput)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRouteRequest indicates an expected call of DeleteTransitGatewayRouteRequest
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteRequest), arg0)
+}
+
+// DeleteTransitGatewayRouteTable mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRouteTable(arg0 *ec2.DeleteTransitGatewayRouteTableInput) (*ec2.DeleteTransitGatewayRouteTableOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteTable", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRouteTable indicates an expected call of DeleteTransitGatewayRouteTable
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteTable), arg0)
+}
+
+// DeleteTransitGatewayRouteTableWithContext mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRouteTableWithContext(arg0 aws.Context, arg1 *ec2.DeleteTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayRouteTableOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteTableWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRouteTableWithContext indicates an expected call of DeleteTransitGatewayRouteTableWithContext
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteTableWithContext), varargs...)
+}
+
+// DeleteTransitGatewayRouteTableRequest mocks base method
+func (m *MockEC2API) DeleteTransitGatewayRouteTableRequest(arg0 *ec2.DeleteTransitGatewayRouteTableInput) (*request.Request, *ec2.DeleteTransitGatewayRouteTableOutput) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteTableRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayRouteTableOutput)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayRouteTableRequest indicates an expected call of DeleteTransitGatewayRouteTableRequest
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteTableRequest), arg0)
+}
+
+// DeleteTransitGatewayVpcAttachment mocks base method
+func (m *MockEC2API) DeleteTransitGatewayVpcAttachment(arg0 *ec2.DeleteTransitGatewayVpcAttachmentInput) (*ec2.DeleteTransitGatewayVpcAttachmentOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayVpcAttachment", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayVpcAttachment indicates an expected call of DeleteTransitGatewayVpcAttachment
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayVpcAttachment), arg0)
+}
+
+// DeleteTransitGatewayVpcAttachmentWithContext mocks base method
+func (m *MockEC2API) DeleteTransitGatewayVpcAttachmentWithContext(arg0 aws.Context, arg1 *ec2.DeleteTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayVpcAttachmentOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayVpcAttachmentWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayVpcAttachmentWithContext indicates an expected call of DeleteTransitGatewayVpcAttachmentWithContext
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayVpcAttachmentWithContext), varargs...)
+}
+
+// DeleteTransitGatewayVpcAttachmentRequest mocks base method
+func (m *MockEC2API) DeleteTransitGatewayVpcAttachmentRequest(arg0 *ec2.DeleteTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.DeleteTransitGatewayVpcAttachmentOutput) {
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayVpcAttachmentRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayVpcAttachmentOutput)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayVpcAttachmentRequest indicates an expected call of DeleteTransitGatewayVpcAttachmentRequest
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayVpcAttachmentRequest), arg0)
+}
+
 // DeleteVolume mocks base method
 func (m *MockEC2API) DeleteVolume(arg0 *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
 	ret := m.ctrl.Call(m, "DeleteVolume", arg0)
@@ -5049,6 +5797,226 @@ func (m *MockEC2API) DescribeClassicLinkInstancesRequest(arg0 *ec2.DescribeClass
 // DescribeClassicLinkInstancesRequest indicates an expected call of DescribeClassicLinkInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeClassicLinkInstancesRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClassicLinkInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClassicLinkInstancesRequest), arg0)
+}
+
+// DescribeClientVpnAuthorizationRules mocks base method
+func (m *MockEC2API) DescribeClientVpnAuthorizationRules(arg0 *ec2.DescribeClientVpnAuthorizationRulesInput) (*ec2.DescribeClientVpnAuthorizationRulesOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnAuthorizationRules", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnAuthorizationRulesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnAuthorizationRules indicates an expected call of DescribeClientVpnAuthorizationRules
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnAuthorizationRules(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnAuthorizationRules", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnAuthorizationRules), arg0)
+}
+
+// DescribeClientVpnAuthorizationRulesWithContext mocks base method
+func (m *MockEC2API) DescribeClientVpnAuthorizationRulesWithContext(arg0 aws.Context, arg1 *ec2.DescribeClientVpnAuthorizationRulesInput, arg2 ...request.Option) (*ec2.DescribeClientVpnAuthorizationRulesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeClientVpnAuthorizationRulesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnAuthorizationRulesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnAuthorizationRulesWithContext indicates an expected call of DescribeClientVpnAuthorizationRulesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnAuthorizationRulesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnAuthorizationRulesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnAuthorizationRulesWithContext), varargs...)
+}
+
+// DescribeClientVpnAuthorizationRulesRequest mocks base method
+func (m *MockEC2API) DescribeClientVpnAuthorizationRulesRequest(arg0 *ec2.DescribeClientVpnAuthorizationRulesInput) (*request.Request, *ec2.DescribeClientVpnAuthorizationRulesOutput) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnAuthorizationRulesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeClientVpnAuthorizationRulesOutput)
+	return ret0, ret1
+}
+
+// DescribeClientVpnAuthorizationRulesRequest indicates an expected call of DescribeClientVpnAuthorizationRulesRequest
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnAuthorizationRulesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnAuthorizationRulesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnAuthorizationRulesRequest), arg0)
+}
+
+// DescribeClientVpnConnections mocks base method
+func (m *MockEC2API) DescribeClientVpnConnections(arg0 *ec2.DescribeClientVpnConnectionsInput) (*ec2.DescribeClientVpnConnectionsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnConnections", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnConnectionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnConnections indicates an expected call of DescribeClientVpnConnections
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnConnections(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnConnections", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnConnections), arg0)
+}
+
+// DescribeClientVpnConnectionsWithContext mocks base method
+func (m *MockEC2API) DescribeClientVpnConnectionsWithContext(arg0 aws.Context, arg1 *ec2.DescribeClientVpnConnectionsInput, arg2 ...request.Option) (*ec2.DescribeClientVpnConnectionsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeClientVpnConnectionsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnConnectionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnConnectionsWithContext indicates an expected call of DescribeClientVpnConnectionsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnConnectionsWithContext), varargs...)
+}
+
+// DescribeClientVpnConnectionsRequest mocks base method
+func (m *MockEC2API) DescribeClientVpnConnectionsRequest(arg0 *ec2.DescribeClientVpnConnectionsInput) (*request.Request, *ec2.DescribeClientVpnConnectionsOutput) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnConnectionsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeClientVpnConnectionsOutput)
+	return ret0, ret1
+}
+
+// DescribeClientVpnConnectionsRequest indicates an expected call of DescribeClientVpnConnectionsRequest
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnConnectionsRequest), arg0)
+}
+
+// DescribeClientVpnEndpoints mocks base method
+func (m *MockEC2API) DescribeClientVpnEndpoints(arg0 *ec2.DescribeClientVpnEndpointsInput) (*ec2.DescribeClientVpnEndpointsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnEndpoints", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnEndpointsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnEndpoints indicates an expected call of DescribeClientVpnEndpoints
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnEndpoints(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnEndpoints", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnEndpoints), arg0)
+}
+
+// DescribeClientVpnEndpointsWithContext mocks base method
+func (m *MockEC2API) DescribeClientVpnEndpointsWithContext(arg0 aws.Context, arg1 *ec2.DescribeClientVpnEndpointsInput, arg2 ...request.Option) (*ec2.DescribeClientVpnEndpointsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeClientVpnEndpointsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnEndpointsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnEndpointsWithContext indicates an expected call of DescribeClientVpnEndpointsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnEndpointsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnEndpointsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnEndpointsWithContext), varargs...)
+}
+
+// DescribeClientVpnEndpointsRequest mocks base method
+func (m *MockEC2API) DescribeClientVpnEndpointsRequest(arg0 *ec2.DescribeClientVpnEndpointsInput) (*request.Request, *ec2.DescribeClientVpnEndpointsOutput) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnEndpointsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeClientVpnEndpointsOutput)
+	return ret0, ret1
+}
+
+// DescribeClientVpnEndpointsRequest indicates an expected call of DescribeClientVpnEndpointsRequest
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnEndpointsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnEndpointsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnEndpointsRequest), arg0)
+}
+
+// DescribeClientVpnRoutes mocks base method
+func (m *MockEC2API) DescribeClientVpnRoutes(arg0 *ec2.DescribeClientVpnRoutesInput) (*ec2.DescribeClientVpnRoutesOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnRoutes", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnRoutesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnRoutes indicates an expected call of DescribeClientVpnRoutes
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnRoutes(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnRoutes", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnRoutes), arg0)
+}
+
+// DescribeClientVpnRoutesWithContext mocks base method
+func (m *MockEC2API) DescribeClientVpnRoutesWithContext(arg0 aws.Context, arg1 *ec2.DescribeClientVpnRoutesInput, arg2 ...request.Option) (*ec2.DescribeClientVpnRoutesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeClientVpnRoutesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnRoutesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnRoutesWithContext indicates an expected call of DescribeClientVpnRoutesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnRoutesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnRoutesWithContext), varargs...)
+}
+
+// DescribeClientVpnRoutesRequest mocks base method
+func (m *MockEC2API) DescribeClientVpnRoutesRequest(arg0 *ec2.DescribeClientVpnRoutesInput) (*request.Request, *ec2.DescribeClientVpnRoutesOutput) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnRoutesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeClientVpnRoutesOutput)
+	return ret0, ret1
+}
+
+// DescribeClientVpnRoutesRequest indicates an expected call of DescribeClientVpnRoutesRequest
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnRoutesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnRoutesRequest), arg0)
+}
+
+// DescribeClientVpnTargetNetworks mocks base method
+func (m *MockEC2API) DescribeClientVpnTargetNetworks(arg0 *ec2.DescribeClientVpnTargetNetworksInput) (*ec2.DescribeClientVpnTargetNetworksOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnTargetNetworks", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnTargetNetworksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnTargetNetworks indicates an expected call of DescribeClientVpnTargetNetworks
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnTargetNetworks(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnTargetNetworks", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnTargetNetworks), arg0)
+}
+
+// DescribeClientVpnTargetNetworksWithContext mocks base method
+func (m *MockEC2API) DescribeClientVpnTargetNetworksWithContext(arg0 aws.Context, arg1 *ec2.DescribeClientVpnTargetNetworksInput, arg2 ...request.Option) (*ec2.DescribeClientVpnTargetNetworksOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeClientVpnTargetNetworksWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeClientVpnTargetNetworksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClientVpnTargetNetworksWithContext indicates an expected call of DescribeClientVpnTargetNetworksWithContext
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnTargetNetworksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnTargetNetworksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnTargetNetworksWithContext), varargs...)
+}
+
+// DescribeClientVpnTargetNetworksRequest mocks base method
+func (m *MockEC2API) DescribeClientVpnTargetNetworksRequest(arg0 *ec2.DescribeClientVpnTargetNetworksInput) (*request.Request, *ec2.DescribeClientVpnTargetNetworksOutput) {
+	ret := m.ctrl.Call(m, "DescribeClientVpnTargetNetworksRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeClientVpnTargetNetworksOutput)
+	return ret0, ret1
+}
+
+// DescribeClientVpnTargetNetworksRequest indicates an expected call of DescribeClientVpnTargetNetworksRequest
+func (mr *MockEC2APIMockRecorder) DescribeClientVpnTargetNetworksRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnTargetNetworksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnTargetNetworksRequest), arg0)
 }
 
 // DescribeConversionTasks mocks base method
@@ -7249,6 +8217,35 @@ func (mr *MockEC2APIMockRecorder) DescribeRouteTablesRequest(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesRequest), arg0)
 }
 
+// DescribeRouteTablesPages mocks base method
+func (m *MockEC2API) DescribeRouteTablesPages(arg0 *ec2.DescribeRouteTablesInput, arg1 func(*ec2.DescribeRouteTablesOutput, bool) bool) error {
+	ret := m.ctrl.Call(m, "DescribeRouteTablesPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeRouteTablesPages indicates an expected call of DescribeRouteTablesPages
+func (mr *MockEC2APIMockRecorder) DescribeRouteTablesPages(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesPages), arg0, arg1)
+}
+
+// DescribeRouteTablesPagesWithContext mocks base method
+func (m *MockEC2API) DescribeRouteTablesPagesWithContext(arg0 aws.Context, arg1 *ec2.DescribeRouteTablesInput, arg2 func(*ec2.DescribeRouteTablesOutput, bool) bool, arg3 ...request.Option) error {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeRouteTablesPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeRouteTablesPagesWithContext indicates an expected call of DescribeRouteTablesPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeRouteTablesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesPagesWithContext), varargs...)
+}
+
 // DescribeScheduledInstanceAvailability mocks base method
 func (m *MockEC2API) DescribeScheduledInstanceAvailability(arg0 *ec2.DescribeScheduledInstanceAvailabilityInput) (*ec2.DescribeScheduledInstanceAvailabilityOutput, error) {
 	ret := m.ctrl.Call(m, "DescribeScheduledInstanceAvailability", arg0)
@@ -7423,6 +8420,35 @@ func (m *MockEC2API) DescribeSecurityGroupsRequest(arg0 *ec2.DescribeSecurityGro
 // DescribeSecurityGroupsRequest indicates an expected call of DescribeSecurityGroupsRequest
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsRequest), arg0)
+}
+
+// DescribeSecurityGroupsPages mocks base method
+func (m *MockEC2API) DescribeSecurityGroupsPages(arg0 *ec2.DescribeSecurityGroupsInput, arg1 func(*ec2.DescribeSecurityGroupsOutput, bool) bool) error {
+	ret := m.ctrl.Call(m, "DescribeSecurityGroupsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeSecurityGroupsPages indicates an expected call of DescribeSecurityGroupsPages
+func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsPages(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsPages), arg0, arg1)
+}
+
+// DescribeSecurityGroupsPagesWithContext mocks base method
+func (m *MockEC2API) DescribeSecurityGroupsPagesWithContext(arg0 aws.Context, arg1 *ec2.DescribeSecurityGroupsInput, arg2 func(*ec2.DescribeSecurityGroupsOutput, bool) bool, arg3 ...request.Option) error {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeSecurityGroupsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeSecurityGroupsPagesWithContext indicates an expected call of DescribeSecurityGroupsPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsPagesWithContext), varargs...)
 }
 
 // DescribeSnapshotAttribute mocks base method
@@ -8023,6 +9049,182 @@ func (m *MockEC2API) DescribeTagsPagesWithContext(arg0 aws.Context, arg1 *ec2.De
 func (mr *MockEC2APIMockRecorder) DescribeTagsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTagsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTagsPagesWithContext), varargs...)
+}
+
+// DescribeTransitGatewayAttachments mocks base method
+func (m *MockEC2API) DescribeTransitGatewayAttachments(arg0 *ec2.DescribeTransitGatewayAttachmentsInput) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayAttachments", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayAttachmentsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayAttachments indicates an expected call of DescribeTransitGatewayAttachments
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachments(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachments", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachments), arg0)
+}
+
+// DescribeTransitGatewayAttachmentsWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayAttachmentsWithContext(arg0 aws.Context, arg1 *ec2.DescribeTransitGatewayAttachmentsInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayAttachmentsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayAttachmentsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayAttachmentsWithContext indicates an expected call of DescribeTransitGatewayAttachmentsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachmentsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachmentsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachmentsWithContext), varargs...)
+}
+
+// DescribeTransitGatewayAttachmentsRequest mocks base method
+func (m *MockEC2API) DescribeTransitGatewayAttachmentsRequest(arg0 *ec2.DescribeTransitGatewayAttachmentsInput) (*request.Request, *ec2.DescribeTransitGatewayAttachmentsOutput) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayAttachmentsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayAttachmentsOutput)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayAttachmentsRequest indicates an expected call of DescribeTransitGatewayAttachmentsRequest
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachmentsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachmentsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachmentsRequest), arg0)
+}
+
+// DescribeTransitGatewayRouteTables mocks base method
+func (m *MockEC2API) DescribeTransitGatewayRouteTables(arg0 *ec2.DescribeTransitGatewayRouteTablesInput) (*ec2.DescribeTransitGatewayRouteTablesOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayRouteTables", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayRouteTablesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayRouteTables indicates an expected call of DescribeTransitGatewayRouteTables
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayRouteTables(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayRouteTables", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayRouteTables), arg0)
+}
+
+// DescribeTransitGatewayRouteTablesWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayRouteTablesWithContext(arg0 aws.Context, arg1 *ec2.DescribeTransitGatewayRouteTablesInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayRouteTablesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayRouteTablesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayRouteTablesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayRouteTablesWithContext indicates an expected call of DescribeTransitGatewayRouteTablesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayRouteTablesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayRouteTablesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayRouteTablesWithContext), varargs...)
+}
+
+// DescribeTransitGatewayRouteTablesRequest mocks base method
+func (m *MockEC2API) DescribeTransitGatewayRouteTablesRequest(arg0 *ec2.DescribeTransitGatewayRouteTablesInput) (*request.Request, *ec2.DescribeTransitGatewayRouteTablesOutput) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayRouteTablesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayRouteTablesOutput)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayRouteTablesRequest indicates an expected call of DescribeTransitGatewayRouteTablesRequest
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayRouteTablesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayRouteTablesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayRouteTablesRequest), arg0)
+}
+
+// DescribeTransitGatewayVpcAttachments mocks base method
+func (m *MockEC2API) DescribeTransitGatewayVpcAttachments(arg0 *ec2.DescribeTransitGatewayVpcAttachmentsInput) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayVpcAttachments", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayVpcAttachmentsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayVpcAttachments indicates an expected call of DescribeTransitGatewayVpcAttachments
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayVpcAttachments(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayVpcAttachments", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayVpcAttachments), arg0)
+}
+
+// DescribeTransitGatewayVpcAttachmentsWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayVpcAttachmentsWithContext(arg0 aws.Context, arg1 *ec2.DescribeTransitGatewayVpcAttachmentsInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayVpcAttachmentsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayVpcAttachmentsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayVpcAttachmentsWithContext indicates an expected call of DescribeTransitGatewayVpcAttachmentsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayVpcAttachmentsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayVpcAttachmentsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayVpcAttachmentsWithContext), varargs...)
+}
+
+// DescribeTransitGatewayVpcAttachmentsRequest mocks base method
+func (m *MockEC2API) DescribeTransitGatewayVpcAttachmentsRequest(arg0 *ec2.DescribeTransitGatewayVpcAttachmentsInput) (*request.Request, *ec2.DescribeTransitGatewayVpcAttachmentsOutput) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayVpcAttachmentsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayVpcAttachmentsOutput)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayVpcAttachmentsRequest indicates an expected call of DescribeTransitGatewayVpcAttachmentsRequest
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayVpcAttachmentsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayVpcAttachmentsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayVpcAttachmentsRequest), arg0)
+}
+
+// DescribeTransitGateways mocks base method
+func (m *MockEC2API) DescribeTransitGateways(arg0 *ec2.DescribeTransitGatewaysInput) (*ec2.DescribeTransitGatewaysOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeTransitGateways", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewaysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGateways indicates an expected call of DescribeTransitGateways
+func (mr *MockEC2APIMockRecorder) DescribeTransitGateways(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGateways), arg0)
+}
+
+// DescribeTransitGatewaysWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewaysWithContext(arg0 aws.Context, arg1 *ec2.DescribeTransitGatewaysInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewaysOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewaysWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewaysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewaysWithContext indicates an expected call of DescribeTransitGatewaysWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewaysWithContext), varargs...)
+}
+
+// DescribeTransitGatewaysRequest mocks base method
+func (m *MockEC2API) DescribeTransitGatewaysRequest(arg0 *ec2.DescribeTransitGatewaysInput) (*request.Request, *ec2.DescribeTransitGatewaysOutput) {
+	ret := m.ctrl.Call(m, "DescribeTransitGatewaysRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTransitGatewaysOutput)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewaysRequest indicates an expected call of DescribeTransitGatewaysRequest
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewaysRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewaysRequest), arg0)
 }
 
 // DescribeVolumeAttribute mocks base method
@@ -9051,6 +10253,50 @@ func (mr *MockEC2APIMockRecorder) DetachVpnGatewayRequest(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DetachVpnGatewayRequest), arg0)
 }
 
+// DisableTransitGatewayRouteTablePropagation mocks base method
+func (m *MockEC2API) DisableTransitGatewayRouteTablePropagation(arg0 *ec2.DisableTransitGatewayRouteTablePropagationInput) (*ec2.DisableTransitGatewayRouteTablePropagationOutput, error) {
+	ret := m.ctrl.Call(m, "DisableTransitGatewayRouteTablePropagation", arg0)
+	ret0, _ := ret[0].(*ec2.DisableTransitGatewayRouteTablePropagationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisableTransitGatewayRouteTablePropagation indicates an expected call of DisableTransitGatewayRouteTablePropagation
+func (mr *MockEC2APIMockRecorder) DisableTransitGatewayRouteTablePropagation(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableTransitGatewayRouteTablePropagation", reflect.TypeOf((*MockEC2API)(nil).DisableTransitGatewayRouteTablePropagation), arg0)
+}
+
+// DisableTransitGatewayRouteTablePropagationWithContext mocks base method
+func (m *MockEC2API) DisableTransitGatewayRouteTablePropagationWithContext(arg0 aws.Context, arg1 *ec2.DisableTransitGatewayRouteTablePropagationInput, arg2 ...request.Option) (*ec2.DisableTransitGatewayRouteTablePropagationOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DisableTransitGatewayRouteTablePropagationWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DisableTransitGatewayRouteTablePropagationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisableTransitGatewayRouteTablePropagationWithContext indicates an expected call of DisableTransitGatewayRouteTablePropagationWithContext
+func (mr *MockEC2APIMockRecorder) DisableTransitGatewayRouteTablePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableTransitGatewayRouteTablePropagationWithContext", reflect.TypeOf((*MockEC2API)(nil).DisableTransitGatewayRouteTablePropagationWithContext), varargs...)
+}
+
+// DisableTransitGatewayRouteTablePropagationRequest mocks base method
+func (m *MockEC2API) DisableTransitGatewayRouteTablePropagationRequest(arg0 *ec2.DisableTransitGatewayRouteTablePropagationInput) (*request.Request, *ec2.DisableTransitGatewayRouteTablePropagationOutput) {
+	ret := m.ctrl.Call(m, "DisableTransitGatewayRouteTablePropagationRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisableTransitGatewayRouteTablePropagationOutput)
+	return ret0, ret1
+}
+
+// DisableTransitGatewayRouteTablePropagationRequest indicates an expected call of DisableTransitGatewayRouteTablePropagationRequest
+func (mr *MockEC2APIMockRecorder) DisableTransitGatewayRouteTablePropagationRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableTransitGatewayRouteTablePropagationRequest", reflect.TypeOf((*MockEC2API)(nil).DisableTransitGatewayRouteTablePropagationRequest), arg0)
+}
+
 // DisableVgwRoutePropagation mocks base method
 func (m *MockEC2API) DisableVgwRoutePropagation(arg0 *ec2.DisableVgwRoutePropagationInput) (*ec2.DisableVgwRoutePropagationOutput, error) {
 	ret := m.ctrl.Call(m, "DisableVgwRoutePropagation", arg0)
@@ -9227,6 +10473,50 @@ func (mr *MockEC2APIMockRecorder) DisassociateAddressRequest(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateAddressRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateAddressRequest), arg0)
 }
 
+// DisassociateClientVpnTargetNetwork mocks base method
+func (m *MockEC2API) DisassociateClientVpnTargetNetwork(arg0 *ec2.DisassociateClientVpnTargetNetworkInput) (*ec2.DisassociateClientVpnTargetNetworkOutput, error) {
+	ret := m.ctrl.Call(m, "DisassociateClientVpnTargetNetwork", arg0)
+	ret0, _ := ret[0].(*ec2.DisassociateClientVpnTargetNetworkOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateClientVpnTargetNetwork indicates an expected call of DisassociateClientVpnTargetNetwork
+func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetwork(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetwork", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetwork), arg0)
+}
+
+// DisassociateClientVpnTargetNetworkWithContext mocks base method
+func (m *MockEC2API) DisassociateClientVpnTargetNetworkWithContext(arg0 aws.Context, arg1 *ec2.DisassociateClientVpnTargetNetworkInput, arg2 ...request.Option) (*ec2.DisassociateClientVpnTargetNetworkOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DisassociateClientVpnTargetNetworkWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DisassociateClientVpnTargetNetworkOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateClientVpnTargetNetworkWithContext indicates an expected call of DisassociateClientVpnTargetNetworkWithContext
+func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetworkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetworkWithContext), varargs...)
+}
+
+// DisassociateClientVpnTargetNetworkRequest mocks base method
+func (m *MockEC2API) DisassociateClientVpnTargetNetworkRequest(arg0 *ec2.DisassociateClientVpnTargetNetworkInput) (*request.Request, *ec2.DisassociateClientVpnTargetNetworkOutput) {
+	ret := m.ctrl.Call(m, "DisassociateClientVpnTargetNetworkRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateClientVpnTargetNetworkOutput)
+	return ret0, ret1
+}
+
+// DisassociateClientVpnTargetNetworkRequest indicates an expected call of DisassociateClientVpnTargetNetworkRequest
+func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetworkRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetworkRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetworkRequest), arg0)
+}
+
 // DisassociateIamInstanceProfile mocks base method
 func (m *MockEC2API) DisassociateIamInstanceProfile(arg0 *ec2.DisassociateIamInstanceProfileInput) (*ec2.DisassociateIamInstanceProfileOutput, error) {
 	ret := m.ctrl.Call(m, "DisassociateIamInstanceProfile", arg0)
@@ -9359,6 +10649,50 @@ func (mr *MockEC2APIMockRecorder) DisassociateSubnetCidrBlockRequest(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateSubnetCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateSubnetCidrBlockRequest), arg0)
 }
 
+// DisassociateTransitGatewayRouteTable mocks base method
+func (m *MockEC2API) DisassociateTransitGatewayRouteTable(arg0 *ec2.DisassociateTransitGatewayRouteTableInput) (*ec2.DisassociateTransitGatewayRouteTableOutput, error) {
+	ret := m.ctrl.Call(m, "DisassociateTransitGatewayRouteTable", arg0)
+	ret0, _ := ret[0].(*ec2.DisassociateTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateTransitGatewayRouteTable indicates an expected call of DisassociateTransitGatewayRouteTable
+func (mr *MockEC2APIMockRecorder) DisassociateTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).DisassociateTransitGatewayRouteTable), arg0)
+}
+
+// DisassociateTransitGatewayRouteTableWithContext mocks base method
+func (m *MockEC2API) DisassociateTransitGatewayRouteTableWithContext(arg0 aws.Context, arg1 *ec2.DisassociateTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.DisassociateTransitGatewayRouteTableOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DisassociateTransitGatewayRouteTableWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DisassociateTransitGatewayRouteTableOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateTransitGatewayRouteTableWithContext indicates an expected call of DisassociateTransitGatewayRouteTableWithContext
+func (mr *MockEC2APIMockRecorder) DisassociateTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateTransitGatewayRouteTableWithContext), varargs...)
+}
+
+// DisassociateTransitGatewayRouteTableRequest mocks base method
+func (m *MockEC2API) DisassociateTransitGatewayRouteTableRequest(arg0 *ec2.DisassociateTransitGatewayRouteTableInput) (*request.Request, *ec2.DisassociateTransitGatewayRouteTableOutput) {
+	ret := m.ctrl.Call(m, "DisassociateTransitGatewayRouteTableRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateTransitGatewayRouteTableOutput)
+	return ret0, ret1
+}
+
+// DisassociateTransitGatewayRouteTableRequest indicates an expected call of DisassociateTransitGatewayRouteTableRequest
+func (mr *MockEC2APIMockRecorder) DisassociateTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateTransitGatewayRouteTableRequest), arg0)
+}
+
 // DisassociateVpcCidrBlock mocks base method
 func (m *MockEC2API) DisassociateVpcCidrBlock(arg0 *ec2.DisassociateVpcCidrBlockInput) (*ec2.DisassociateVpcCidrBlockOutput, error) {
 	ret := m.ctrl.Call(m, "DisassociateVpcCidrBlock", arg0)
@@ -9401,6 +10735,50 @@ func (m *MockEC2API) DisassociateVpcCidrBlockRequest(arg0 *ec2.DisassociateVpcCi
 // DisassociateVpcCidrBlockRequest indicates an expected call of DisassociateVpcCidrBlockRequest
 func (mr *MockEC2APIMockRecorder) DisassociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateVpcCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateVpcCidrBlockRequest), arg0)
+}
+
+// EnableTransitGatewayRouteTablePropagation mocks base method
+func (m *MockEC2API) EnableTransitGatewayRouteTablePropagation(arg0 *ec2.EnableTransitGatewayRouteTablePropagationInput) (*ec2.EnableTransitGatewayRouteTablePropagationOutput, error) {
+	ret := m.ctrl.Call(m, "EnableTransitGatewayRouteTablePropagation", arg0)
+	ret0, _ := ret[0].(*ec2.EnableTransitGatewayRouteTablePropagationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnableTransitGatewayRouteTablePropagation indicates an expected call of EnableTransitGatewayRouteTablePropagation
+func (mr *MockEC2APIMockRecorder) EnableTransitGatewayRouteTablePropagation(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableTransitGatewayRouteTablePropagation", reflect.TypeOf((*MockEC2API)(nil).EnableTransitGatewayRouteTablePropagation), arg0)
+}
+
+// EnableTransitGatewayRouteTablePropagationWithContext mocks base method
+func (m *MockEC2API) EnableTransitGatewayRouteTablePropagationWithContext(arg0 aws.Context, arg1 *ec2.EnableTransitGatewayRouteTablePropagationInput, arg2 ...request.Option) (*ec2.EnableTransitGatewayRouteTablePropagationOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnableTransitGatewayRouteTablePropagationWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.EnableTransitGatewayRouteTablePropagationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnableTransitGatewayRouteTablePropagationWithContext indicates an expected call of EnableTransitGatewayRouteTablePropagationWithContext
+func (mr *MockEC2APIMockRecorder) EnableTransitGatewayRouteTablePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableTransitGatewayRouteTablePropagationWithContext", reflect.TypeOf((*MockEC2API)(nil).EnableTransitGatewayRouteTablePropagationWithContext), varargs...)
+}
+
+// EnableTransitGatewayRouteTablePropagationRequest mocks base method
+func (m *MockEC2API) EnableTransitGatewayRouteTablePropagationRequest(arg0 *ec2.EnableTransitGatewayRouteTablePropagationInput) (*request.Request, *ec2.EnableTransitGatewayRouteTablePropagationOutput) {
+	ret := m.ctrl.Call(m, "EnableTransitGatewayRouteTablePropagationRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.EnableTransitGatewayRouteTablePropagationOutput)
+	return ret0, ret1
+}
+
+// EnableTransitGatewayRouteTablePropagationRequest indicates an expected call of EnableTransitGatewayRouteTablePropagationRequest
+func (mr *MockEC2APIMockRecorder) EnableTransitGatewayRouteTablePropagationRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableTransitGatewayRouteTablePropagationRequest", reflect.TypeOf((*MockEC2API)(nil).EnableTransitGatewayRouteTablePropagationRequest), arg0)
 }
 
 // EnableVgwRoutePropagation mocks base method
@@ -9577,6 +10955,138 @@ func (m *MockEC2API) EnableVpcClassicLinkDnsSupportRequest(arg0 *ec2.EnableVpcCl
 // EnableVpcClassicLinkDnsSupportRequest indicates an expected call of EnableVpcClassicLinkDnsSupportRequest
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLinkDnsSupportRequest", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLinkDnsSupportRequest), arg0)
+}
+
+// ExportClientVpnClientCertificateRevocationList mocks base method
+func (m *MockEC2API) ExportClientVpnClientCertificateRevocationList(arg0 *ec2.ExportClientVpnClientCertificateRevocationListInput) (*ec2.ExportClientVpnClientCertificateRevocationListOutput, error) {
+	ret := m.ctrl.Call(m, "ExportClientVpnClientCertificateRevocationList", arg0)
+	ret0, _ := ret[0].(*ec2.ExportClientVpnClientCertificateRevocationListOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportClientVpnClientCertificateRevocationList indicates an expected call of ExportClientVpnClientCertificateRevocationList
+func (mr *MockEC2APIMockRecorder) ExportClientVpnClientCertificateRevocationList(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientCertificateRevocationList", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientCertificateRevocationList), arg0)
+}
+
+// ExportClientVpnClientCertificateRevocationListWithContext mocks base method
+func (m *MockEC2API) ExportClientVpnClientCertificateRevocationListWithContext(arg0 aws.Context, arg1 *ec2.ExportClientVpnClientCertificateRevocationListInput, arg2 ...request.Option) (*ec2.ExportClientVpnClientCertificateRevocationListOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExportClientVpnClientCertificateRevocationListWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ExportClientVpnClientCertificateRevocationListOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportClientVpnClientCertificateRevocationListWithContext indicates an expected call of ExportClientVpnClientCertificateRevocationListWithContext
+func (mr *MockEC2APIMockRecorder) ExportClientVpnClientCertificateRevocationListWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientCertificateRevocationListWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientCertificateRevocationListWithContext), varargs...)
+}
+
+// ExportClientVpnClientCertificateRevocationListRequest mocks base method
+func (m *MockEC2API) ExportClientVpnClientCertificateRevocationListRequest(arg0 *ec2.ExportClientVpnClientCertificateRevocationListInput) (*request.Request, *ec2.ExportClientVpnClientCertificateRevocationListOutput) {
+	ret := m.ctrl.Call(m, "ExportClientVpnClientCertificateRevocationListRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ExportClientVpnClientCertificateRevocationListOutput)
+	return ret0, ret1
+}
+
+// ExportClientVpnClientCertificateRevocationListRequest indicates an expected call of ExportClientVpnClientCertificateRevocationListRequest
+func (mr *MockEC2APIMockRecorder) ExportClientVpnClientCertificateRevocationListRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientCertificateRevocationListRequest", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientCertificateRevocationListRequest), arg0)
+}
+
+// ExportClientVpnClientConfiguration mocks base method
+func (m *MockEC2API) ExportClientVpnClientConfiguration(arg0 *ec2.ExportClientVpnClientConfigurationInput) (*ec2.ExportClientVpnClientConfigurationOutput, error) {
+	ret := m.ctrl.Call(m, "ExportClientVpnClientConfiguration", arg0)
+	ret0, _ := ret[0].(*ec2.ExportClientVpnClientConfigurationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportClientVpnClientConfiguration indicates an expected call of ExportClientVpnClientConfiguration
+func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfiguration(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfiguration", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfiguration), arg0)
+}
+
+// ExportClientVpnClientConfigurationWithContext mocks base method
+func (m *MockEC2API) ExportClientVpnClientConfigurationWithContext(arg0 aws.Context, arg1 *ec2.ExportClientVpnClientConfigurationInput, arg2 ...request.Option) (*ec2.ExportClientVpnClientConfigurationOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExportClientVpnClientConfigurationWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ExportClientVpnClientConfigurationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportClientVpnClientConfigurationWithContext indicates an expected call of ExportClientVpnClientConfigurationWithContext
+func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfigurationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfigurationWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfigurationWithContext), varargs...)
+}
+
+// ExportClientVpnClientConfigurationRequest mocks base method
+func (m *MockEC2API) ExportClientVpnClientConfigurationRequest(arg0 *ec2.ExportClientVpnClientConfigurationInput) (*request.Request, *ec2.ExportClientVpnClientConfigurationOutput) {
+	ret := m.ctrl.Call(m, "ExportClientVpnClientConfigurationRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ExportClientVpnClientConfigurationOutput)
+	return ret0, ret1
+}
+
+// ExportClientVpnClientConfigurationRequest indicates an expected call of ExportClientVpnClientConfigurationRequest
+func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfigurationRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfigurationRequest", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfigurationRequest), arg0)
+}
+
+// ExportTransitGatewayRoutes mocks base method
+func (m *MockEC2API) ExportTransitGatewayRoutes(arg0 *ec2.ExportTransitGatewayRoutesInput) (*ec2.ExportTransitGatewayRoutesOutput, error) {
+	ret := m.ctrl.Call(m, "ExportTransitGatewayRoutes", arg0)
+	ret0, _ := ret[0].(*ec2.ExportTransitGatewayRoutesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportTransitGatewayRoutes indicates an expected call of ExportTransitGatewayRoutes
+func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutes(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutes", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutes), arg0)
+}
+
+// ExportTransitGatewayRoutesWithContext mocks base method
+func (m *MockEC2API) ExportTransitGatewayRoutesWithContext(arg0 aws.Context, arg1 *ec2.ExportTransitGatewayRoutesInput, arg2 ...request.Option) (*ec2.ExportTransitGatewayRoutesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExportTransitGatewayRoutesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ExportTransitGatewayRoutesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportTransitGatewayRoutesWithContext indicates an expected call of ExportTransitGatewayRoutesWithContext
+func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutesWithContext), varargs...)
+}
+
+// ExportTransitGatewayRoutesRequest mocks base method
+func (m *MockEC2API) ExportTransitGatewayRoutesRequest(arg0 *ec2.ExportTransitGatewayRoutesInput) (*request.Request, *ec2.ExportTransitGatewayRoutesOutput) {
+	ret := m.ctrl.Call(m, "ExportTransitGatewayRoutesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ExportTransitGatewayRoutesOutput)
+	return ret0, ret1
+}
+
+// ExportTransitGatewayRoutesRequest indicates an expected call of ExportTransitGatewayRoutesRequest
+func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutesRequest), arg0)
 }
 
 // GetConsoleOutput mocks base method
@@ -9843,6 +11353,182 @@ func (mr *MockEC2APIMockRecorder) GetReservedInstancesExchangeQuoteRequest(arg0 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReservedInstancesExchangeQuoteRequest", reflect.TypeOf((*MockEC2API)(nil).GetReservedInstancesExchangeQuoteRequest), arg0)
 }
 
+// GetTransitGatewayAttachmentPropagations mocks base method
+func (m *MockEC2API) GetTransitGatewayAttachmentPropagations(arg0 *ec2.GetTransitGatewayAttachmentPropagationsInput) (*ec2.GetTransitGatewayAttachmentPropagationsOutput, error) {
+	ret := m.ctrl.Call(m, "GetTransitGatewayAttachmentPropagations", arg0)
+	ret0, _ := ret[0].(*ec2.GetTransitGatewayAttachmentPropagationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransitGatewayAttachmentPropagations indicates an expected call of GetTransitGatewayAttachmentPropagations
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayAttachmentPropagations(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayAttachmentPropagations", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayAttachmentPropagations), arg0)
+}
+
+// GetTransitGatewayAttachmentPropagationsWithContext mocks base method
+func (m *MockEC2API) GetTransitGatewayAttachmentPropagationsWithContext(arg0 aws.Context, arg1 *ec2.GetTransitGatewayAttachmentPropagationsInput, arg2 ...request.Option) (*ec2.GetTransitGatewayAttachmentPropagationsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetTransitGatewayAttachmentPropagationsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.GetTransitGatewayAttachmentPropagationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransitGatewayAttachmentPropagationsWithContext indicates an expected call of GetTransitGatewayAttachmentPropagationsWithContext
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayAttachmentPropagationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayAttachmentPropagationsWithContext", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayAttachmentPropagationsWithContext), varargs...)
+}
+
+// GetTransitGatewayAttachmentPropagationsRequest mocks base method
+func (m *MockEC2API) GetTransitGatewayAttachmentPropagationsRequest(arg0 *ec2.GetTransitGatewayAttachmentPropagationsInput) (*request.Request, *ec2.GetTransitGatewayAttachmentPropagationsOutput) {
+	ret := m.ctrl.Call(m, "GetTransitGatewayAttachmentPropagationsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetTransitGatewayAttachmentPropagationsOutput)
+	return ret0, ret1
+}
+
+// GetTransitGatewayAttachmentPropagationsRequest indicates an expected call of GetTransitGatewayAttachmentPropagationsRequest
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayAttachmentPropagationsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayAttachmentPropagationsRequest", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayAttachmentPropagationsRequest), arg0)
+}
+
+// GetTransitGatewayRouteTableAssociations mocks base method
+func (m *MockEC2API) GetTransitGatewayRouteTableAssociations(arg0 *ec2.GetTransitGatewayRouteTableAssociationsInput) (*ec2.GetTransitGatewayRouteTableAssociationsOutput, error) {
+	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTableAssociations", arg0)
+	ret0, _ := ret[0].(*ec2.GetTransitGatewayRouteTableAssociationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransitGatewayRouteTableAssociations indicates an expected call of GetTransitGatewayRouteTableAssociations
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTableAssociations(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTableAssociations", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTableAssociations), arg0)
+}
+
+// GetTransitGatewayRouteTableAssociationsWithContext mocks base method
+func (m *MockEC2API) GetTransitGatewayRouteTableAssociationsWithContext(arg0 aws.Context, arg1 *ec2.GetTransitGatewayRouteTableAssociationsInput, arg2 ...request.Option) (*ec2.GetTransitGatewayRouteTableAssociationsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTableAssociationsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.GetTransitGatewayRouteTableAssociationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransitGatewayRouteTableAssociationsWithContext indicates an expected call of GetTransitGatewayRouteTableAssociationsWithContext
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTableAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTableAssociationsWithContext", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTableAssociationsWithContext), varargs...)
+}
+
+// GetTransitGatewayRouteTableAssociationsRequest mocks base method
+func (m *MockEC2API) GetTransitGatewayRouteTableAssociationsRequest(arg0 *ec2.GetTransitGatewayRouteTableAssociationsInput) (*request.Request, *ec2.GetTransitGatewayRouteTableAssociationsOutput) {
+	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTableAssociationsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetTransitGatewayRouteTableAssociationsOutput)
+	return ret0, ret1
+}
+
+// GetTransitGatewayRouteTableAssociationsRequest indicates an expected call of GetTransitGatewayRouteTableAssociationsRequest
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTableAssociationsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTableAssociationsRequest", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTableAssociationsRequest), arg0)
+}
+
+// GetTransitGatewayRouteTablePropagations mocks base method
+func (m *MockEC2API) GetTransitGatewayRouteTablePropagations(arg0 *ec2.GetTransitGatewayRouteTablePropagationsInput) (*ec2.GetTransitGatewayRouteTablePropagationsOutput, error) {
+	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTablePropagations", arg0)
+	ret0, _ := ret[0].(*ec2.GetTransitGatewayRouteTablePropagationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransitGatewayRouteTablePropagations indicates an expected call of GetTransitGatewayRouteTablePropagations
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTablePropagations(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTablePropagations", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTablePropagations), arg0)
+}
+
+// GetTransitGatewayRouteTablePropagationsWithContext mocks base method
+func (m *MockEC2API) GetTransitGatewayRouteTablePropagationsWithContext(arg0 aws.Context, arg1 *ec2.GetTransitGatewayRouteTablePropagationsInput, arg2 ...request.Option) (*ec2.GetTransitGatewayRouteTablePropagationsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTablePropagationsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.GetTransitGatewayRouteTablePropagationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransitGatewayRouteTablePropagationsWithContext indicates an expected call of GetTransitGatewayRouteTablePropagationsWithContext
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTablePropagationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTablePropagationsWithContext", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTablePropagationsWithContext), varargs...)
+}
+
+// GetTransitGatewayRouteTablePropagationsRequest mocks base method
+func (m *MockEC2API) GetTransitGatewayRouteTablePropagationsRequest(arg0 *ec2.GetTransitGatewayRouteTablePropagationsInput) (*request.Request, *ec2.GetTransitGatewayRouteTablePropagationsOutput) {
+	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTablePropagationsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetTransitGatewayRouteTablePropagationsOutput)
+	return ret0, ret1
+}
+
+// GetTransitGatewayRouteTablePropagationsRequest indicates an expected call of GetTransitGatewayRouteTablePropagationsRequest
+func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTablePropagationsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTablePropagationsRequest", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTablePropagationsRequest), arg0)
+}
+
+// ImportClientVpnClientCertificateRevocationList mocks base method
+func (m *MockEC2API) ImportClientVpnClientCertificateRevocationList(arg0 *ec2.ImportClientVpnClientCertificateRevocationListInput) (*ec2.ImportClientVpnClientCertificateRevocationListOutput, error) {
+	ret := m.ctrl.Call(m, "ImportClientVpnClientCertificateRevocationList", arg0)
+	ret0, _ := ret[0].(*ec2.ImportClientVpnClientCertificateRevocationListOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportClientVpnClientCertificateRevocationList indicates an expected call of ImportClientVpnClientCertificateRevocationList
+func (mr *MockEC2APIMockRecorder) ImportClientVpnClientCertificateRevocationList(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportClientVpnClientCertificateRevocationList", reflect.TypeOf((*MockEC2API)(nil).ImportClientVpnClientCertificateRevocationList), arg0)
+}
+
+// ImportClientVpnClientCertificateRevocationListWithContext mocks base method
+func (m *MockEC2API) ImportClientVpnClientCertificateRevocationListWithContext(arg0 aws.Context, arg1 *ec2.ImportClientVpnClientCertificateRevocationListInput, arg2 ...request.Option) (*ec2.ImportClientVpnClientCertificateRevocationListOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ImportClientVpnClientCertificateRevocationListWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ImportClientVpnClientCertificateRevocationListOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportClientVpnClientCertificateRevocationListWithContext indicates an expected call of ImportClientVpnClientCertificateRevocationListWithContext
+func (mr *MockEC2APIMockRecorder) ImportClientVpnClientCertificateRevocationListWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportClientVpnClientCertificateRevocationListWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportClientVpnClientCertificateRevocationListWithContext), varargs...)
+}
+
+// ImportClientVpnClientCertificateRevocationListRequest mocks base method
+func (m *MockEC2API) ImportClientVpnClientCertificateRevocationListRequest(arg0 *ec2.ImportClientVpnClientCertificateRevocationListInput) (*request.Request, *ec2.ImportClientVpnClientCertificateRevocationListOutput) {
+	ret := m.ctrl.Call(m, "ImportClientVpnClientCertificateRevocationListRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ImportClientVpnClientCertificateRevocationListOutput)
+	return ret0, ret1
+}
+
+// ImportClientVpnClientCertificateRevocationListRequest indicates an expected call of ImportClientVpnClientCertificateRevocationListRequest
+func (mr *MockEC2APIMockRecorder) ImportClientVpnClientCertificateRevocationListRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportClientVpnClientCertificateRevocationListRequest", reflect.TypeOf((*MockEC2API)(nil).ImportClientVpnClientCertificateRevocationListRequest), arg0)
+}
+
 // ImportImage mocks base method
 func (m *MockEC2API) ImportImage(arg0 *ec2.ImportImageInput) (*ec2.ImportImageOutput, error) {
 	ret := m.ctrl.Call(m, "ImportImage", arg0)
@@ -10105,6 +11791,50 @@ func (m *MockEC2API) ModifyCapacityReservationRequest(arg0 *ec2.ModifyCapacityRe
 // ModifyCapacityReservationRequest indicates an expected call of ModifyCapacityReservationRequest
 func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationRequest), arg0)
+}
+
+// ModifyClientVpnEndpoint mocks base method
+func (m *MockEC2API) ModifyClientVpnEndpoint(arg0 *ec2.ModifyClientVpnEndpointInput) (*ec2.ModifyClientVpnEndpointOutput, error) {
+	ret := m.ctrl.Call(m, "ModifyClientVpnEndpoint", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyClientVpnEndpointOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyClientVpnEndpoint indicates an expected call of ModifyClientVpnEndpoint
+func (mr *MockEC2APIMockRecorder) ModifyClientVpnEndpoint(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyClientVpnEndpoint", reflect.TypeOf((*MockEC2API)(nil).ModifyClientVpnEndpoint), arg0)
+}
+
+// ModifyClientVpnEndpointWithContext mocks base method
+func (m *MockEC2API) ModifyClientVpnEndpointWithContext(arg0 aws.Context, arg1 *ec2.ModifyClientVpnEndpointInput, arg2 ...request.Option) (*ec2.ModifyClientVpnEndpointOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyClientVpnEndpointWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyClientVpnEndpointOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyClientVpnEndpointWithContext indicates an expected call of ModifyClientVpnEndpointWithContext
+func (mr *MockEC2APIMockRecorder) ModifyClientVpnEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyClientVpnEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyClientVpnEndpointWithContext), varargs...)
+}
+
+// ModifyClientVpnEndpointRequest mocks base method
+func (m *MockEC2API) ModifyClientVpnEndpointRequest(arg0 *ec2.ModifyClientVpnEndpointInput) (*request.Request, *ec2.ModifyClientVpnEndpointOutput) {
+	ret := m.ctrl.Call(m, "ModifyClientVpnEndpointRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyClientVpnEndpointOutput)
+	return ret0, ret1
+}
+
+// ModifyClientVpnEndpointRequest indicates an expected call of ModifyClientVpnEndpointRequest
+func (mr *MockEC2APIMockRecorder) ModifyClientVpnEndpointRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyClientVpnEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyClientVpnEndpointRequest), arg0)
 }
 
 // ModifyFleet mocks base method
@@ -10809,6 +12539,50 @@ func (m *MockEC2API) ModifySubnetAttributeRequest(arg0 *ec2.ModifySubnetAttribut
 // ModifySubnetAttributeRequest indicates an expected call of ModifySubnetAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifySubnetAttributeRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySubnetAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifySubnetAttributeRequest), arg0)
+}
+
+// ModifyTransitGatewayVpcAttachment mocks base method
+func (m *MockEC2API) ModifyTransitGatewayVpcAttachment(arg0 *ec2.ModifyTransitGatewayVpcAttachmentInput) (*ec2.ModifyTransitGatewayVpcAttachmentOutput, error) {
+	ret := m.ctrl.Call(m, "ModifyTransitGatewayVpcAttachment", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyTransitGatewayVpcAttachment indicates an expected call of ModifyTransitGatewayVpcAttachment
+func (mr *MockEC2APIMockRecorder) ModifyTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).ModifyTransitGatewayVpcAttachment), arg0)
+}
+
+// ModifyTransitGatewayVpcAttachmentWithContext mocks base method
+func (m *MockEC2API) ModifyTransitGatewayVpcAttachmentWithContext(arg0 aws.Context, arg1 *ec2.ModifyTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.ModifyTransitGatewayVpcAttachmentOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyTransitGatewayVpcAttachmentWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyTransitGatewayVpcAttachmentWithContext indicates an expected call of ModifyTransitGatewayVpcAttachmentWithContext
+func (mr *MockEC2APIMockRecorder) ModifyTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyTransitGatewayVpcAttachmentWithContext), varargs...)
+}
+
+// ModifyTransitGatewayVpcAttachmentRequest mocks base method
+func (m *MockEC2API) ModifyTransitGatewayVpcAttachmentRequest(arg0 *ec2.ModifyTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.ModifyTransitGatewayVpcAttachmentOutput) {
+	ret := m.ctrl.Call(m, "ModifyTransitGatewayVpcAttachmentRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyTransitGatewayVpcAttachmentOutput)
+	return ret0, ret1
+}
+
+// ModifyTransitGatewayVpcAttachmentRequest indicates an expected call of ModifyTransitGatewayVpcAttachmentRequest
+func (mr *MockEC2APIMockRecorder) ModifyTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyTransitGatewayVpcAttachmentRequest), arg0)
 }
 
 // ModifyVolume mocks base method
@@ -11559,6 +13333,50 @@ func (mr *MockEC2APIMockRecorder) RegisterImageRequest(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterImageRequest", reflect.TypeOf((*MockEC2API)(nil).RegisterImageRequest), arg0)
 }
 
+// RejectTransitGatewayVpcAttachment mocks base method
+func (m *MockEC2API) RejectTransitGatewayVpcAttachment(arg0 *ec2.RejectTransitGatewayVpcAttachmentInput) (*ec2.RejectTransitGatewayVpcAttachmentOutput, error) {
+	ret := m.ctrl.Call(m, "RejectTransitGatewayVpcAttachment", arg0)
+	ret0, _ := ret[0].(*ec2.RejectTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RejectTransitGatewayVpcAttachment indicates an expected call of RejectTransitGatewayVpcAttachment
+func (mr *MockEC2APIMockRecorder) RejectTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayVpcAttachment), arg0)
+}
+
+// RejectTransitGatewayVpcAttachmentWithContext mocks base method
+func (m *MockEC2API) RejectTransitGatewayVpcAttachmentWithContext(arg0 aws.Context, arg1 *ec2.RejectTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.RejectTransitGatewayVpcAttachmentOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RejectTransitGatewayVpcAttachmentWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.RejectTransitGatewayVpcAttachmentOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RejectTransitGatewayVpcAttachmentWithContext indicates an expected call of RejectTransitGatewayVpcAttachmentWithContext
+func (mr *MockEC2APIMockRecorder) RejectTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayVpcAttachmentWithContext), varargs...)
+}
+
+// RejectTransitGatewayVpcAttachmentRequest mocks base method
+func (m *MockEC2API) RejectTransitGatewayVpcAttachmentRequest(arg0 *ec2.RejectTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.RejectTransitGatewayVpcAttachmentOutput) {
+	ret := m.ctrl.Call(m, "RejectTransitGatewayVpcAttachmentRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RejectTransitGatewayVpcAttachmentOutput)
+	return ret0, ret1
+}
+
+// RejectTransitGatewayVpcAttachmentRequest indicates an expected call of RejectTransitGatewayVpcAttachmentRequest
+func (mr *MockEC2APIMockRecorder) RejectTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayVpcAttachmentRequest), arg0)
+}
+
 // RejectVpcEndpointConnections mocks base method
 func (m *MockEC2API) RejectVpcEndpointConnections(arg0 *ec2.RejectVpcEndpointConnectionsInput) (*ec2.RejectVpcEndpointConnectionsOutput, error) {
 	ret := m.ctrl.Call(m, "RejectVpcEndpointConnections", arg0)
@@ -11953,6 +13771,50 @@ func (m *MockEC2API) ReplaceRouteTableAssociationRequest(arg0 *ec2.ReplaceRouteT
 // ReplaceRouteTableAssociationRequest indicates an expected call of ReplaceRouteTableAssociationRequest
 func (mr *MockEC2APIMockRecorder) ReplaceRouteTableAssociationRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRouteTableAssociationRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceRouteTableAssociationRequest), arg0)
+}
+
+// ReplaceTransitGatewayRoute mocks base method
+func (m *MockEC2API) ReplaceTransitGatewayRoute(arg0 *ec2.ReplaceTransitGatewayRouteInput) (*ec2.ReplaceTransitGatewayRouteOutput, error) {
+	ret := m.ctrl.Call(m, "ReplaceTransitGatewayRoute", arg0)
+	ret0, _ := ret[0].(*ec2.ReplaceTransitGatewayRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReplaceTransitGatewayRoute indicates an expected call of ReplaceTransitGatewayRoute
+func (mr *MockEC2APIMockRecorder) ReplaceTransitGatewayRoute(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTransitGatewayRoute", reflect.TypeOf((*MockEC2API)(nil).ReplaceTransitGatewayRoute), arg0)
+}
+
+// ReplaceTransitGatewayRouteWithContext mocks base method
+func (m *MockEC2API) ReplaceTransitGatewayRouteWithContext(arg0 aws.Context, arg1 *ec2.ReplaceTransitGatewayRouteInput, arg2 ...request.Option) (*ec2.ReplaceTransitGatewayRouteOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReplaceTransitGatewayRouteWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ReplaceTransitGatewayRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReplaceTransitGatewayRouteWithContext indicates an expected call of ReplaceTransitGatewayRouteWithContext
+func (mr *MockEC2APIMockRecorder) ReplaceTransitGatewayRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTransitGatewayRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceTransitGatewayRouteWithContext), varargs...)
+}
+
+// ReplaceTransitGatewayRouteRequest mocks base method
+func (m *MockEC2API) ReplaceTransitGatewayRouteRequest(arg0 *ec2.ReplaceTransitGatewayRouteInput) (*request.Request, *ec2.ReplaceTransitGatewayRouteOutput) {
+	ret := m.ctrl.Call(m, "ReplaceTransitGatewayRouteRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReplaceTransitGatewayRouteOutput)
+	return ret0, ret1
+}
+
+// ReplaceTransitGatewayRouteRequest indicates an expected call of ReplaceTransitGatewayRouteRequest
+func (mr *MockEC2APIMockRecorder) ReplaceTransitGatewayRouteRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTransitGatewayRouteRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceTransitGatewayRouteRequest), arg0)
 }
 
 // ReportInstanceStatus mocks base method
@@ -12351,6 +14213,50 @@ func (mr *MockEC2APIMockRecorder) RestoreAddressToClassicRequest(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreAddressToClassicRequest", reflect.TypeOf((*MockEC2API)(nil).RestoreAddressToClassicRequest), arg0)
 }
 
+// RevokeClientVpnIngress mocks base method
+func (m *MockEC2API) RevokeClientVpnIngress(arg0 *ec2.RevokeClientVpnIngressInput) (*ec2.RevokeClientVpnIngressOutput, error) {
+	ret := m.ctrl.Call(m, "RevokeClientVpnIngress", arg0)
+	ret0, _ := ret[0].(*ec2.RevokeClientVpnIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeClientVpnIngress indicates an expected call of RevokeClientVpnIngress
+func (mr *MockEC2APIMockRecorder) RevokeClientVpnIngress(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeClientVpnIngress", reflect.TypeOf((*MockEC2API)(nil).RevokeClientVpnIngress), arg0)
+}
+
+// RevokeClientVpnIngressWithContext mocks base method
+func (m *MockEC2API) RevokeClientVpnIngressWithContext(arg0 aws.Context, arg1 *ec2.RevokeClientVpnIngressInput, arg2 ...request.Option) (*ec2.RevokeClientVpnIngressOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RevokeClientVpnIngressWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.RevokeClientVpnIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeClientVpnIngressWithContext indicates an expected call of RevokeClientVpnIngressWithContext
+func (mr *MockEC2APIMockRecorder) RevokeClientVpnIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeClientVpnIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).RevokeClientVpnIngressWithContext), varargs...)
+}
+
+// RevokeClientVpnIngressRequest mocks base method
+func (m *MockEC2API) RevokeClientVpnIngressRequest(arg0 *ec2.RevokeClientVpnIngressInput) (*request.Request, *ec2.RevokeClientVpnIngressOutput) {
+	ret := m.ctrl.Call(m, "RevokeClientVpnIngressRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RevokeClientVpnIngressOutput)
+	return ret0, ret1
+}
+
+// RevokeClientVpnIngressRequest indicates an expected call of RevokeClientVpnIngressRequest
+func (mr *MockEC2APIMockRecorder) RevokeClientVpnIngressRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeClientVpnIngressRequest", reflect.TypeOf((*MockEC2API)(nil).RevokeClientVpnIngressRequest), arg0)
+}
+
 // RevokeSecurityGroupEgress mocks base method
 func (m *MockEC2API) RevokeSecurityGroupEgress(arg0 *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
 	ret := m.ctrl.Call(m, "RevokeSecurityGroupEgress", arg0)
@@ -12527,6 +14433,50 @@ func (mr *MockEC2APIMockRecorder) RunScheduledInstancesRequest(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunScheduledInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).RunScheduledInstancesRequest), arg0)
 }
 
+// SearchTransitGatewayRoutes mocks base method
+func (m *MockEC2API) SearchTransitGatewayRoutes(arg0 *ec2.SearchTransitGatewayRoutesInput) (*ec2.SearchTransitGatewayRoutesOutput, error) {
+	ret := m.ctrl.Call(m, "SearchTransitGatewayRoutes", arg0)
+	ret0, _ := ret[0].(*ec2.SearchTransitGatewayRoutesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchTransitGatewayRoutes indicates an expected call of SearchTransitGatewayRoutes
+func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutes(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutes", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutes), arg0)
+}
+
+// SearchTransitGatewayRoutesWithContext mocks base method
+func (m *MockEC2API) SearchTransitGatewayRoutesWithContext(arg0 aws.Context, arg1 *ec2.SearchTransitGatewayRoutesInput, arg2 ...request.Option) (*ec2.SearchTransitGatewayRoutesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SearchTransitGatewayRoutesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.SearchTransitGatewayRoutesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchTransitGatewayRoutesWithContext indicates an expected call of SearchTransitGatewayRoutesWithContext
+func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutesWithContext), varargs...)
+}
+
+// SearchTransitGatewayRoutesRequest mocks base method
+func (m *MockEC2API) SearchTransitGatewayRoutesRequest(arg0 *ec2.SearchTransitGatewayRoutesInput) (*request.Request, *ec2.SearchTransitGatewayRoutesOutput) {
+	ret := m.ctrl.Call(m, "SearchTransitGatewayRoutesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.SearchTransitGatewayRoutesOutput)
+	return ret0, ret1
+}
+
+// SearchTransitGatewayRoutesRequest indicates an expected call of SearchTransitGatewayRoutesRequest
+func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutesRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutesRequest), arg0)
+}
+
 // StartInstances mocks base method
 func (m *MockEC2API) StartInstances(arg0 *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
 	ret := m.ctrl.Call(m, "StartInstances", arg0)
@@ -12613,6 +14563,50 @@ func (m *MockEC2API) StopInstancesRequest(arg0 *ec2.StopInstancesInput) (*reques
 // StopInstancesRequest indicates an expected call of StopInstancesRequest
 func (mr *MockEC2APIMockRecorder) StopInstancesRequest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).StopInstancesRequest), arg0)
+}
+
+// TerminateClientVpnConnections mocks base method
+func (m *MockEC2API) TerminateClientVpnConnections(arg0 *ec2.TerminateClientVpnConnectionsInput) (*ec2.TerminateClientVpnConnectionsOutput, error) {
+	ret := m.ctrl.Call(m, "TerminateClientVpnConnections", arg0)
+	ret0, _ := ret[0].(*ec2.TerminateClientVpnConnectionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TerminateClientVpnConnections indicates an expected call of TerminateClientVpnConnections
+func (mr *MockEC2APIMockRecorder) TerminateClientVpnConnections(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateClientVpnConnections", reflect.TypeOf((*MockEC2API)(nil).TerminateClientVpnConnections), arg0)
+}
+
+// TerminateClientVpnConnectionsWithContext mocks base method
+func (m *MockEC2API) TerminateClientVpnConnectionsWithContext(arg0 aws.Context, arg1 *ec2.TerminateClientVpnConnectionsInput, arg2 ...request.Option) (*ec2.TerminateClientVpnConnectionsOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TerminateClientVpnConnectionsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.TerminateClientVpnConnectionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TerminateClientVpnConnectionsWithContext indicates an expected call of TerminateClientVpnConnectionsWithContext
+func (mr *MockEC2APIMockRecorder) TerminateClientVpnConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateClientVpnConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).TerminateClientVpnConnectionsWithContext), varargs...)
+}
+
+// TerminateClientVpnConnectionsRequest mocks base method
+func (m *MockEC2API) TerminateClientVpnConnectionsRequest(arg0 *ec2.TerminateClientVpnConnectionsInput) (*request.Request, *ec2.TerminateClientVpnConnectionsOutput) {
+	ret := m.ctrl.Call(m, "TerminateClientVpnConnectionsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.TerminateClientVpnConnectionsOutput)
+	return ret0, ret1
+}
+
+// TerminateClientVpnConnectionsRequest indicates an expected call of TerminateClientVpnConnectionsRequest
+func (mr *MockEC2APIMockRecorder) TerminateClientVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateClientVpnConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).TerminateClientVpnConnectionsRequest), arg0)
 }
 
 // TerminateInstances mocks base method


### PR DESCRIPTION
Oops, forgot that `dep ensure` and `make mocks` need to be run when updating aws dependencies. /cc: @bjohnso5