### PR TITLE
adds support for secrets in task definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,16 @@ via the --image flag.
 fargate service deploy [--file docker-compose.yml]
 ```
 
-Deploy image and environment variables defined in a [docker compose file](https://docs.docker.com/compose/overview/) to service
+Deploy image, environment variables, and secrets defined in a [docker compose file](https://docs.docker.com/compose/overview/) to service
 
-Deploy a docker [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file together as a single unit. Note that environments variables are replaced with what's in the compose file.
+Deploy a docker [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file together as a single unit. Note that environments variables and secrets are replaced with what's in the compose file.
+
+Secrets can be defined as key-value pairs under the docker compose file extension field `x-fargate-secrets`. To use extension fields, the compose file version must be  at least `2.1` for the 2.x series or at least `3.4` for the 3.x series.
 
 This allows you to run `docker-compose up` locally to run your app the same way it will run in AWS. Note that while the docker-compose yaml configuration supports numerous options, only the image and environment variables are deployed to fargate. If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy. For example:
 
 ```yaml
-version: '3'
+version: '3.4'
 services:
   web:
     build: .
@@ -149,6 +151,8 @@ services:
       BAZ: bam
     env_file:
     - hidden.env
+    x-fargate-secrets:
+      QUX: arn:key:ssm:us-east-1:000000000000:parameter/path/to/my_parameter
     labels:
       aws.ecs.fargate.deploy: 1
   redis:
@@ -164,7 +168,7 @@ fargate service info
 Inspect service
 
 Show extended information for a service including load balancer configuration,
-active deployments, and environment variables.
+active deployments, environment variables, and secrets.
 
 Deployments show active versions of your service that are running. Multiple
 deployments are shown if a service is transitioning due to a deployment or
@@ -233,20 +237,23 @@ specified with a sign such as +5 or -2.
 
 ```console
 fargate service env set [--env <key=value>] [--file <pathname>]
+                        [--secret <key=valueFrom>] [--secret-file <pathname>]
 ```
 
-Set environment variables
+Set environment variables and secrets
 
-At least one environment variable must be specified via either the --env or
---file flags. You may specify any number of variables on the command line by
+At least one environment variable or secret must be specified via either the --env,
+--file,  --secret, or --secret-file flags. You may specify any number of variables on the command line by
 repeating --env before each one, or else place multiple variables in a text
-file, one per line, and specify the filename with --file.
+file, one per line, and specify the filename with --file and/or --secret-file.
 
-Each --env parameter string or line in the file must be of the form
+Each --env and --secret parameter string or line in the file must be of the form
 "key=value", with no quotation marks and no whitespace around the "=" unless you want
 literal leading whitespace in the value.  Additionally, the "key" side must be
 a legal shell identifier, which means it must start with an ASCII letter A-Z or
 underscore and consist of only letters, digits, and underscores.
+
+The "value" in "key=value" for each --secret flag should reference the ARN to the AWS Secrets Manager secret or AWS Systems Manager Parameter Store parameter. 
 
 ##### fargate service env unset
 
@@ -254,9 +261,9 @@ underscore and consist of only letters, digits, and underscores.
 fargate service env unset --key <key-name>
 ```
 
-Unset environment variables
+Unset environment variables and secrets
 
-Unsets the environment variable specified via the --key flag. Specify --key with
+Unsets the environment variable or secret specified via the --key flag. Specify --key with
 a key name multiple times to unset multiple variables.
 
 ##### fargate service env list
@@ -327,7 +334,9 @@ Console, or until they are interrupted for any reason.
 ##### fargate task register
 
 ```console
-fargate task register [--image <docker-image>] [-e KEY=value -e KEY2=value] [--env-file dev.env]
+fargate task register [--image <docker-image>] [-e KEY=value -e KEY2=value] 
+                      [--env-file dev.env] [--secret KEY3=valueFrom] 
+                      [--secret-file secrets.env]
 ```
 
 Registers a new [task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for the specified docker image or environment variables based on the latest revision of the task family and returns the new revision number.
@@ -340,7 +349,9 @@ via the --image flag.
 fargate task register [--file docker-compose.yml]
 ```
 
-Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) using the [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file. Note that environments variables are replaced with what's in the compose file.
+Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) using the [image](https://docs.docker.com/compose/compose-file/#image), [environment variables](https://docs.docker.com/compose/environment-variables/), and secrets defined in a docker compose file. Note that environments variables are replaced with what's in the compose file.
+
+Secrets can be defined as key-value pairs under the docker compose file extension field `x-fargate-secrets`. To use extension fields, the compose file version must be  at least `2.1` for the 2.x series or at least `3.4` for the 3.x series.
 
 If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"regexp"
@@ -193,6 +194,22 @@ func extractEnvVars(inputEnvVars []string) []ECS.EnvVar {
 	}
 
 	return envVars
+}
+
+func readVarFile(filename string) []string {
+	var result []string
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return result
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		result = append(result, scanner.Text())
+	}
+
+	return result
 }
 
 func validateCpuAndMemory(inputCpuUnits, inputMebibytes string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -70,3 +70,26 @@ func TestValidateCpuAndMemory(t *testing.T) {
 		}
 	}
 }
+
+func TestReadEnvFile(t *testing.T) {
+	expected := []string{"FOO=bar", "BAR=baz"}
+	results := readVarFile("./testdata/test.env")
+
+	if len(results) != len(expected) {
+		t.Errorf("Expected %d results, got %d results", len(expected), len(results))
+	}
+
+	for i, entry := range results {
+		if entry != expected[i] {
+			t.Errorf("Expected %s, got %s", expected[i], entry)
+		}
+	}
+}
+
+func TestReadEnvFileMissing(t *testing.T) {
+	results := readVarFile("missing.env")
+
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results, got %d results", len(results))
+	}
+}

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -112,7 +112,7 @@ func deployDockerComposeFile(operation *ServiceDeployOperation) {
 		taskDefinitionArn = ecs.UpdateTaskDefinitionImage(ecsService.TaskDefinitionArn, dockerService.Image)
 	} else {
 		//register a new task definition based on the image and environment variables from the compose file
-		taskDefinitionArn = ecs.UpdateTaskDefinitionImageAndEnvVars(ecsService.TaskDefinitionArn, dockerService.Image, envvars, true)
+		taskDefinitionArn = ecs.UpdateTaskDefinitionImageAndEnvVars(ecsService.TaskDefinitionArn, dockerService.Image, envvars, true, ecsService.SecretVars)
 	}
 
 	//update service with new task definition

--- a/cmd/service_env_set.go
+++ b/cmd/service_env_set.go
@@ -12,16 +12,21 @@ import (
 type ServiceEnvSetOperation struct {
 	ServiceName string
 	EnvVars     []ECS.EnvVar
+	SecretVars  []ECS.EnvVar
 }
 
 func (o *ServiceEnvSetOperation) Validate() {
-	if len(o.EnvVars) == 0 {
-		console.IssueExit("No environment variables specified")
+	if len(o.EnvVars) == 0 && len(o.SecretVars) == 0 {
+		console.IssueExit("No environment variables or secrets specified")
 	}
 }
 
 func (o *ServiceEnvSetOperation) SetEnvVars(inputEnvVars []string, envVarFile string) {
 	o.EnvVars = processEnvVarArgs(inputEnvVars, envVarFile)
+}
+
+func (o *ServiceEnvSetOperation) SetSecretVars(inputSecretVars []string, secretVarFile string) {
+	o.SecretVars = processEnvVarArgs(inputSecretVars, secretVarFile)
 }
 
 func processEnvVarArgs(inputEnvVars []string, envVarFile string) []ECS.EnvVar {
@@ -41,18 +46,20 @@ func processEnvVarArgs(inputEnvVars []string, envVarFile string) []ECS.EnvVar {
 
 var flagServiceEnvSetEnvVars []string
 var flagServiceEnvSetEnvFile string
+var flagServiceEnvSetSecretVars []string
+var flagServiceEnvSetSecretFile string
 
 var serviceEnvSetCmd = &cobra.Command{
-	Use:   "set --env <key=value> [--env <key=value] [--file filename] ...",
+	Use:   "set --env <key=value> [--env <key=value>] [--file filename] [--secret <key=valueFrom>] [--secret-file filename]...",
 	Short: "Set environment variables",
 	Long: `Set environment variables
 
-At least one environment variable must be specified via either the --env or
---file flags. You may specify any number of variables on the command line by
-repeating --env before each one, or else place multiple variables in a file, one
-per line, and specify the filename with --file.
+At least one environment variable must be specified via either the --env, --secret,
+--file, or --secret-file flags. You may specify any number of variables on the command line by
+repeating --env or --secret before each one, or else place multiple variables in a file, one
+per line, and specify the filename with --file or --secret-file.
 
-Each --env parameter string or line in the file must be of the form
+Each --env and --secret parameter string or line in the file must be of the form
 "key=value", with no quotation marks and no whitespace around the "=" unless you want
 literal leading whitespace in the value.  Additionally, the "key" side must be
 a legal shell identifier, which means it must start with an ASCII letter A-Z or
@@ -63,6 +70,7 @@ underscore and consist of only letters, digits, and underscores.`,
 		}
 
 		operation.SetEnvVars(flagServiceEnvSetEnvVars, flagServiceEnvSetEnvFile)
+		operation.SetSecretVars(flagServiceEnvSetSecretVars, flagServiceEnvSetSecretFile)
 		operation.Validate()
 		serviceEnvSet(operation)
 	},
@@ -71,6 +79,8 @@ underscore and consist of only letters, digits, and underscores.`,
 func init() {
 	serviceEnvSetCmd.Flags().StringArrayVarP(&flagServiceEnvSetEnvVars, "env", "e", []string{}, "Environment variables to set [e.g. KEY=value]")
 	serviceEnvSetCmd.Flags().StringVarP(&flagServiceEnvSetEnvFile, "file", "f", "", "File containing list of environment variables to set, one per line, of the form KEY=value")
+	serviceEnvSetCmd.Flags().StringArrayVar(&flagServiceEnvSetSecretVars, "secret", []string{}, "Secret variables to set [e.g. KEY=valueFrom]")
+	serviceEnvSetCmd.Flags().StringVar(&flagServiceEnvSetSecretFile, "secret-file", "", "File containing list of secret variables to set, one per line, of the form KEY=valueFrom")
 
 	serviceEnvCmd.AddCommand(serviceEnvSetCmd)
 }
@@ -78,14 +88,23 @@ func init() {
 func serviceEnvSet(operation *ServiceEnvSetOperation) {
 	ecs := ECS.New(sess, getClusterName())
 	service := ecs.DescribeService(operation.ServiceName)
-	taskDefinitionArn := ecs.AddEnvVarsToTaskDefinition(service.TaskDefinitionArn, operation.EnvVars)
+	taskDefinitionArn := ecs.AddEnvVarsToTaskDefinition(service.TaskDefinitionArn, operation.EnvVars, operation.SecretVars)
 
 	ecs.UpdateServiceTaskDefinition(operation.ServiceName, taskDefinitionArn)
 
-	console.Info("Set %s environment variables:", operation.ServiceName)
+	if len(operation.EnvVars) > 0 {
+		console.Info("Set %s environment variables:", operation.ServiceName)
 
-	for _, envVar := range operation.EnvVars {
-		console.Info("- %s=%s", envVar.Key, envVar.Value)
+		for _, envVar := range operation.EnvVars {
+			console.Info("- %s=%s", envVar.Key, envVar.Value)
+		}
 	}
 
+	if len(operation.SecretVars) > 0 {
+		console.Info("Set %s secret variables:", operation.ServiceName)
+
+		for _, envVar := range operation.SecretVars {
+			console.Info("- %s=%s", envVar.Key, envVar.Value)
+		}
+	}
 }

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -125,6 +125,16 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 		}
 	}
 
+	if len(service.SecretVars) > 0 {
+		console.KeyValue("Secrets", "\n")
+
+		ecs.SortEnvVars(service.SecretVars)
+
+		for _, secret := range service.SecretVars {
+			fmt.Printf("   %s=%s\n", secret.Key, secret.Value)
+		}
+	}
+
 	if len(service.ServiceRegistries) > 0 {
 		console.Header("Service Discovery")
 

--- a/cmd/task_register.go
+++ b/cmd/task_register.go
@@ -43,7 +43,12 @@ var taskRegisterCmd = &cobra.Command{
 		}
 
 		//valid cli arg combinations
-		nonComposeOptions := (flagTaskRegisterImage != "" || len(flagTaskRegisterEnvVars) > 0 || flagTaskRegisterEnvFile != "")
+		nonComposeOptions := (flagTaskRegisterImage != "" ||
+			len(flagTaskRegisterEnvVars) > 0 ||
+			flagTaskRegisterEnvFile != "" ||
+			len(flagTaskRegisterSecretVars) > 0 ||
+			flagTaskRegisterSecretFile != "")
+
 		if (flagTaskRegisterDockerComposeFile != "" && nonComposeOptions) ||
 			(flagTaskRegisterDockerComposeFile == "" && !nonComposeOptions) {
 			cmd.Help()
@@ -67,13 +72,13 @@ func init() {
 
 	taskRegisterCmd.Flags().StringArrayVarP(&flagTaskRegisterEnvVars, "env", "e", []string{}, "Environment variables to set [e.g. -e KEY=value -e KEY2=value]")
 
-	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterEnvFile, "env-file", "", "", "File containing list of environment variables to set, one per line, of the form KEY=value")
+	taskRegisterCmd.Flags().StringVar(&flagTaskRegisterEnvFile, "env-file", "", "File containing list of environment variables to set, one per line, of the form KEY=value")
 
 	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterDockerComposeFile, "file", "f", "", "Docker Compose file containing image and environment variables to register.")
 
 	taskRegisterCmd.Flags().StringArrayVar(&flagTaskRegisterSecretVars, "secret", []string{}, "Secret variables to set [e.g. --secret KEY=valueFrom --secret KEY2=valueFrom]")
 
-	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterSecretFile, "secret-file", "", "", "File containing list of secret variables to set, one per line, of the form KEY=valueFrom")
+	taskRegisterCmd.Flags().StringVar(&flagTaskRegisterSecretFile, "secret-file", "", "File containing list of secret variables to set, one per line, of the form KEY=valueFrom")
 
 	taskCmd.AddCommand(taskRegisterCmd)
 }

--- a/cmd/testdata/test.env
+++ b/cmd/testdata/test.env
@@ -1,0 +1,2 @@
+FOO=bar
+BAR=baz

--- a/dockercompose/main.go
+++ b/dockercompose/main.go
@@ -23,20 +23,6 @@ func NewComposeFile(file string) ComposeFile {
 // DockerCompose represents a docker-compose.yml file
 type DockerCompose struct {
 	Services map[string]*Service `yaml:"services"`
-	Secrets  map[string]*Secret  `yaml:"secrets,omitempty"`
-}
-
-// Secret represents a docker secret
-type Secret struct {
-	Name     string `yaml:"name,omitempty"`
-	External bool   `yaml:"external,omitempty"`
-	File     string `yaml:"file,omitempty"`
-}
-
-// ServiceSecret represents a docker service secret configuration
-type ServiceSecret struct {
-	Source string `yaml:"source"`
-	Target string `yaml:"target,omitempty"`
 }
 
 // Service represents a docker container
@@ -44,7 +30,7 @@ type Service struct {
 	Image       string            `yaml:"image,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
-	Secrets     []*ServiceSecret  `yaml:"secrets,omitempty"`
+	Secrets     map[string]string `yaml:"x-fargate-secrets,omitempty"`
 }
 
 //Config returns a DockerCompose representation of the file

--- a/dockercompose/main.go
+++ b/dockercompose/main.go
@@ -23,6 +23,20 @@ func NewComposeFile(file string) ComposeFile {
 // DockerCompose represents a docker-compose.yml file
 type DockerCompose struct {
 	Services map[string]*Service `yaml:"services"`
+	Secrets  map[string]*Secret  `yaml:"secrets,omitempty"`
+}
+
+// Secret represents a docker secret
+type Secret struct {
+	Name     string `yaml:"name,omitempty"`
+	External bool   `yaml:"external,omitempty"`
+	File     string `yaml:"file,omitempty"`
+}
+
+// ServiceSecret represents a docker service secret configuration
+type ServiceSecret struct {
+	Source string `yaml:"source"`
+	Target string `yaml:"target,omitempty"`
 }
 
 // Service represents a docker container
@@ -30,6 +44,7 @@ type Service struct {
 	Image       string            `yaml:"image,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
+	Secrets     []*ServiceSecret  `yaml:"secrets,omitempty"`
 }
 
 //Config returns a DockerCompose representation of the file

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -45,6 +45,7 @@ type Service struct {
 	TargetGroupArn    string
 	TaskDefinitionArn string
 	TaskRole          string
+	SecretVars        []EnvVar
 	SubnetIds         []string
 	Status            string
 }
@@ -253,6 +254,16 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 					EnvVar{
 						Key:   aws.StringValue(env.Name),
 						Value: aws.StringValue(env.Value),
+					},
+				)
+			}
+
+			for _, secret := range taskDefinition.ContainerDefinitions[0].Secrets {
+				s.SecretVars = append(
+					s.SecretVars,
+					EnvVar{
+						Key:   aws.StringValue(secret.Name),
+						Value: aws.StringValue(secret.ValueFrom),
 					},
 				)
 			}

--- a/ecs/task_definition.go
+++ b/ecs/task_definition.go
@@ -25,6 +25,7 @@ type CreateTaskDefinitionInput struct {
 	Port             int64
 	LogGroupName     string
 	LogRegion        string
+	SecretVars       []EnvVar
 	TaskRole         string
 	Type             string
 }
@@ -64,6 +65,7 @@ func (ecs *ECS) CreateTaskDefinition(input *CreateTaskDefinitionInput) string {
 		Image:            aws.String(input.Image),
 		LogConfiguration: logConfiguration,
 		Name:             aws.String(input.Name),
+		Secrets:          input.Secrets(),
 	}
 
 	if input.Port != 0 {
@@ -104,6 +106,10 @@ func (input *CreateTaskDefinitionInput) Environment() []*awsecs.KeyValuePair {
 	return convertEnvVars(input.EnvVars)
 }
 
+func (input *CreateTaskDefinitionInput) Secrets() []*awsecs.Secret {
+	return convertSecretVars(input.SecretVars)
+}
+
 func convertEnvVars(envvars []EnvVar) []*awsecs.KeyValuePair {
 	var environment []*awsecs.KeyValuePair
 
@@ -118,6 +124,21 @@ func convertEnvVars(envvars []EnvVar) []*awsecs.KeyValuePair {
 
 	return environment
 
+}
+
+func convertSecretVars(envvars []EnvVar) []*awsecs.Secret {
+	var secrets []*awsecs.Secret
+
+	for _, envVar := range envvars {
+		secrets = append(secrets,
+			&awsecs.Secret{
+				Name:      aws.String(envVar.Key),
+				ValueFrom: aws.String(envVar.Value),
+			},
+		)
+	}
+
+	return secrets
 }
 
 func (ecs *ECS) DescribeTaskDefinition(taskDefinitionArn string) *awsecs.TaskDefinition {
@@ -150,7 +171,7 @@ func (ecs *ECS) UpdateTaskDefinitionImage(taskDefinitionArn, image string) strin
 // UpdateTaskDefinitionImageAndReplaceEnvVars creates a new, updated task definition
 // based on the specified image and env vars.
 // Note that any existing envvars are replaced by the new ones
-func (ecs *ECS) UpdateTaskDefinitionImageAndEnvVars(taskDefinitionArnOrFamily string, image string, environmentVariables []EnvVar, replaceEnvVars bool) string {
+func (ecs *ECS) UpdateTaskDefinitionImageAndEnvVars(taskDefinitionArnOrFamily string, image string, environmentVariables []EnvVar, replaceEnvVars bool, secretVariables []EnvVar) string {
 
 	//fetch task definition details (for specific or latest active)
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArnOrFamily)
@@ -175,6 +196,15 @@ func (ecs *ECS) UpdateTaskDefinitionImageAndEnvVars(taskDefinitionArnOrFamily st
 			for _, e := range envvars {
 				container.Environment = append(container.Environment, e)
 			}
+		}
+	}
+
+	//convert secrets to aws input format
+	if len(secretVariables) > 0 {
+		secrets := convertSecretVars(secretVariables)
+
+		for _, s := range secrets {
+			container.Secrets = append(container.Secrets, s)
 		}
 	}
 
@@ -206,7 +236,7 @@ func (ecs *ECS) registerTaskDefinition(taskDefinition *awsecs.TaskDefinition) st
 }
 
 //AddEnvVarsToTaskDefinition registers a new task definition with the envvars appended
-func (ecs *ECS) AddEnvVarsToTaskDefinition(taskDefinitionArn string, envVars []EnvVar) string {
+func (ecs *ECS) AddEnvVarsToTaskDefinition(taskDefinitionArn string, envVars []EnvVar, secretVars []EnvVar) string {
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
 
 	for _, envVar := range envVars {
@@ -221,16 +251,30 @@ func (ecs *ECS) AddEnvVarsToTaskDefinition(taskDefinitionArn string, envVars []E
 		)
 	}
 
+	for _, envVar := range secretVars {
+		secret := &awsecs.Secret{
+			Name:      aws.String(envVar.Key),
+			ValueFrom: aws.String(envVar.Value),
+		}
+
+		taskDefinition.ContainerDefinitions[0].Secrets = append(
+			taskDefinition.ContainerDefinitions[0].Secrets,
+			secret,
+		)
+	}
+
 	return ecs.registerTaskDefinition(taskDefinition)
 }
 
 //RemoveEnvVarsFromTaskDefinition registers a new task definition with the specified keys removed
 func (ecs *ECS) RemoveEnvVarsFromTaskDefinition(taskDefinitionArn string, keys []string) string {
 	var newEnvironment []*awsecs.KeyValuePair
+	var newSecrets []*awsecs.Secret
 
 	//look up task definition
 	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
 	environment := taskDefinition.ContainerDefinitions[0].Environment
+	secrets := taskDefinition.ContainerDefinitions[0].Secrets
 
 	//iterate existing envvars
 	for _, keyValuePair := range environment {
@@ -250,7 +294,26 @@ func (ecs *ECS) RemoveEnvVarsFromTaskDefinition(taskDefinitionArn string, keys [
 		}
 	}
 
+	//iterate existing secrets
+	for _, secret := range secrets {
+
+		//is this key a match to remove?
+		match := false
+		for _, key := range keys {
+			if aws.StringValue(secret.Name) == key {
+				match = true
+				break
+			}
+		}
+
+		//add this envvar since it wasn't a match to remove
+		if !match {
+			newSecrets = append(newSecrets, secret)
+		}
+	}
+
 	taskDefinition.ContainerDefinitions[0].Environment = newEnvironment
+	taskDefinition.ContainerDefinitions[0].Secrets = newSecrets
 
 	return ecs.registerTaskDefinition(taskDefinition)
 }
@@ -271,6 +334,24 @@ func (ecs *ECS) GetEnvVarsFromTaskDefinition(taskDefinitionArn string) []EnvVar 
 	}
 
 	return envVars
+}
+
+//GetSecretVarsFromTaskDefinition retrieves secret vars from an existing task definition
+func (ecs *ECS) GetSecretVarsFromTaskDefinition(taskDefinitionArn string) []EnvVar {
+	var secretVars []EnvVar
+
+	taskDefinition := ecs.DescribeTaskDefinition(taskDefinitionArn)
+
+	for _, keyValuePair := range taskDefinition.ContainerDefinitions[0].Secrets {
+		secretVars = append(secretVars,
+			EnvVar{
+				Key:   aws.StringValue(keyValuePair.Name),
+				Value: aws.StringValue(keyValuePair.ValueFrom),
+			},
+		)
+	}
+
+	return secretVars
 }
 
 //UpdateTaskDefinitionCpuAndMemory registers a new task definition with the cpu/memory


### PR DESCRIPTION
Adds the ability to manage and inspect secrets in task definitions.

AWS docs for reference -- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html

### `fargate service env set`

* Allows setting the secret key and valueFrom attributes similar to an env var via a `--secret` or `--secret-file` flag: 

```
$ fargate service env set \
    --secret SECRETVAR1=arn:aws:ssm:us-east-1:000000000000:parameter/dev/my-service/var1 \
    --secret SECRETVAR2=/dev/my-service/var2

[i] Set my-service secret variables:
[i] - SECRETVAR1=arn:aws:ssm:us-east-1:000000000000:parameter/dev/my-service/var1
[i] - SECRETVAR2=/dev/my-service/var2
```

* Command will fail if trying to set a secret that exists as an existing environment variable:

```
$ fargate service env set --secret PORT=/dev/my-service/port

[!] Could not register ECS task definition
ClientException: The secret name must be unique and not shared with any new or existing environment variables set on the container, such as 'PORT'.
        status code: 400, request id: b85c4e3a-298f-11e9-92a2-752c7899d9d6
```

### `fargate service env unset`

* Allows unsetting secrets via same method as env vars:

```
$ fargate service env unset --key SECRETVAR1 --key NONSECRET

[i] Unset my-service environment variables:
[i] - NONSECRET
[i] Unset my-service secret variables:
[i] - SECRETVAR1
```

### `fargate task register`

* Allows setting secrets on a new task definition revision via a `--secret` or `--secret-file` flag: 

```
$ fargate task register --secret SECRETVAR=/dev/my-service/var --secret-file=secrets.env

<revision number>
```

### `fargate service info`

* Displays Secrets in same format as Environment Variables, if set:

```
$ fargate service info

Service Name: my-service
Status:
  Desired: 1
  Running: 1
  Pending: 0
Image: 000000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:develop.899a3a7
Cpu: 256
Memory: 512
Task Role: arn:aws:iam::000000000000:role/my-service-dev
Subnets: subnet-aaaaaaaa, subnet-bbbbbbbb
Security Groups: sg-00000000000000000
Load Balancer:
  Name: my-service-dev
  DNS Name: internal-my-service-dev-322164624.us-east-1.elb.amazonaws.com
  Ports:
    HTTP:80:
      Rules: DEFAULT=
Environment Variables:
   HEALTHCHECK=/hc
   PORT=3000
Secrets:
   DB_PASSWORD=arn:aws:ssm:us-east-1:000000000000:parameter/dev/my-service/db_password
   SESSION_SECRET=/dev/my-service/session_secret

Tasks
ID                                      IMAGE                                                                   STATUS  RUNNING IP      CPU     MEMORY  DEPLOYMENT
dc4f56be-1638-4a47-9551-20db792cb456    000000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:develop.899a3a7 running 44m57s          256     512     29

Deployments
ID      IMAGE                                                                   STATUS  CREATED                         DESIRED RUNNING PENDING
29      000000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:develop.899a3a7 primary 2019-02-05 20:57:33 +0000 UTC   1       1       0

Events
[2019-02-05 21:00:34 +0000 UTC] (service my-service) has reached a steady state.
```