### PR TITLE
adds task describe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ fargate task describe
 
 The describe command describes a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) in [Docker Compose](https://docs.docker.com/compose/overview/) format. The Docker image, environment variables, secrets, and target port are the mapped elements.
 
-This command can be useful for looking at changes made by the `task register`, `service deploy`, or `fargate service env set` commands.  It can also be useful for running a task definition locally for debugging or troubleshooting purposes.
+This command can be useful for looking at changes made by the `task register`, `service deploy`, or `service env set` commands.  It can also be useful for running a task definition locally for debugging or troubleshooting purposes.
 
 ```sh
 fargate task describe -t my-app > docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ If the docker compose file defines more than one container, you can use the [lab
 fargate task generate [--file docker-compose.yml]
 ```
 
-The generate command converts a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) into a [Docker Compose File](https://docs.docker.com/compose/overview/).  The Docker image, environment variables, and secrets are the targeted elements.
+The generate command converts a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) into a [Docker Compose File](https://docs.docker.com/compose/overview/).  The Docker image, environment variables, secrets, and target port are the mapped elements.
 
 You can specify the task definition family by using a `fargate.yml` file or using 
 the `-t` flag, including an optional revision number.
@@ -385,7 +385,7 @@ services:
   app:
     image: 1234567890.dkr.ecr.us-east-1.amazonaws.com/my-app:1.0
     ports:
-    - published: 80
+    - published: 8080
       target: 8080
     environment:
       AWS_REGION: us-east-1

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ until you manually stop them either through AWS APIs, the AWS Management
 Console, or until they are interrupted for any reason.
 
 - [register](#fargate-task-register)
-- [generate](#fargate-task-generate)
+- [describe](#fargate-task-describe)
 - [logs](#fargate-task-logs)
 
 
@@ -361,23 +361,30 @@ Secrets can be defined as key-value pairs under the docker compose file extensio
 If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy.
 
 
-##### fargate task generate
+##### fargate task describe
 
 ```console
-fargate task generate [--file docker-compose.yml]
+fargate task describe
 ```
 
-The generate command converts a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) into a [Docker Compose File](https://docs.docker.com/compose/overview/).  The Docker image, environment variables, secrets, and target port are the mapped elements.
+The describe command describes a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) in [Docker Compose](https://docs.docker.com/compose/overview/) format. The Docker image, environment variables, secrets, and target port are the mapped elements.
 
-You can specify the task definition family by using a `fargate.yml` file or using 
+This command can be useful for looking at changes made by the `task register`, `service deploy`, or `fargate service env set` commands.  It can also be useful for running a task definition locally for debugging or troubleshooting purposes.
+
+```sh
+fargate task describe -t my-app > docker-compose.yml
+docker-compose up
+```
+
+You can specify the task definition family by using a `fargate.yml` file, the `FARGATE_TASK` envvar, or using 
 the `-t` flag, including an optional revision number.
 
-```
-fargate task generate -t my-app
-fargate task generate -t my-app:42
+```sh
+fargate task describe -t my-app
+fargate task describe -t my-app:42
 ```
 
-An example of an outputted `docker-compose.yml` file:
+Example output:
 
 ```yaml
 version: "3.7"

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ Deploy image, environment variables, and secrets defined in a [docker compose fi
 
 Deploy a docker [image](https://docs.docker.com/compose/compose-file/#image) and [environment variables](https://docs.docker.com/compose/environment-variables/) defined in a docker compose file together as a single unit. Note that environments variables and secrets are replaced with what's in the compose file.
 
-Secrets can be defined as key-value pairs under the docker compose file extension field `x-fargate-secrets`. To use extension fields, the compose file version must be  at least `2.1` for the 2.x series or at least `3.4` for the 3.x series.
+Secrets can be defined as key-value pairs under the docker compose file extension field `x-fargate-secrets`. To use extension fields, the compose file version must be  at least `2.4` for the 2.x series or at least `3.7` for the 3.x series.
 
 This allows you to run `docker-compose up` locally to run your app the same way it will run in AWS. Note that while the docker-compose yaml configuration supports numerous options, only the image and environment variables are deployed to fargate. If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy. For example:
 
 ```yaml
-version: '3.4'
+version: "3.7"
 services:
   web:
     build: .
@@ -328,21 +328,26 @@ until you manually stop them either through AWS APIs, the AWS Management
 Console, or until they are interrupted for any reason.
 
 - [register](#fargate-task-register)
+- [generate](#fargate-task-generate)
 - [logs](#fargate-task-logs)
 
 
 ##### fargate task register
 
 ```console
-fargate task register [--image <docker-image>] [-e KEY=value -e KEY2=value] 
-                      [--env-file dev.env] [--secret KEY3=valueFrom] 
-                      [--secret-file secrets.env]
+fargate task register [--image <docker-image>] 
+                      [-e KEY=value -e KEY2=value] [--env-file dev.env]
+                      [--secret KEY3=valueFrom] [--secret-file secrets.env]
 ```
 
-Registers a new [task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for the specified docker image or environment variables based on the latest revision of the task family and returns the new revision number.
+Registers a new [task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for the specified docker image, environment variables, or secrets based on the latest revision of the task family and returns the new revision number.
 
 The Docker container image to use in the new Task Definition can be specified
 via the --image flag.
+
+The environment variables can be specified using one or many `--env` flags or the `--env-file` flag.
+
+The secrets can be specified using one or many `--secret` flags or the `--secret-file` flag.
 
 
 ```console
@@ -351,9 +356,47 @@ fargate task register [--file docker-compose.yml]
 
 Registers a new [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) using the [image](https://docs.docker.com/compose/compose-file/#image), [environment variables](https://docs.docker.com/compose/environment-variables/), and secrets defined in a docker compose file. Note that environments variables are replaced with what's in the compose file.
 
-Secrets can be defined as key-value pairs under the docker compose file extension field `x-fargate-secrets`. To use extension fields, the compose file version must be  at least `2.1` for the 2.x series or at least `3.4` for the 3.x series.
+Secrets can be defined as key-value pairs under the docker compose file extension field `x-fargate-secrets`. To use extension fields, the compose file version must be  at least `2.4` for the 2.x series or at least `3.7` for the 3.x series.
 
 If the docker compose file defines more than one container, you can use the [label](https://docs.docker.com/compose/compose-file/#labels) `aws.ecs.fargate.deploy: 1` to indicate which container you would like to deploy.
+
+
+##### fargate task generate
+
+```console
+fargate task generate [--file docker-compose.yml]
+```
+
+The generate command converts a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) into a [Docker Compose File](https://docs.docker.com/compose/overview/).  The Docker image, environment variables, and secrets are the targeted elements.
+
+You can specify the task definition family by using a `fargate.yml` file or using 
+the `-t` flag, including an optional revision number.
+
+```
+fargate task generate -t my-app
+fargate task generate -t my-app:42
+```
+
+An example of an outputted `docker-compose.yml` file:
+
+```yaml
+version: "3.7"
+services:
+  app:
+    image: 1234567890.dkr.ecr.us-east-1.amazonaws.com/my-app:1.0
+    ports:
+    - published: 80
+      target: 8080
+    environment:
+      AWS_REGION: us-east-1
+      ENVIRONMENT: dev
+      FOO: bar
+    x-fargate-secrets:
+      KEY: arn:key:ssm:us-east-1:000000000000:parameter/path/to/my_parameter      
+    labels:
+      aws.ecs.fargate.deploy: "1"
+```
+
 
 ##### fargate task logs
 

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -147,11 +147,10 @@ func deployRevision(operation *ServiceDeployOperation) {
 
 func getDockerServiceFromComposeFile(dockerComposeFile string) *dockercompose.Service {
 	//read the compose file configuration
-	composeFile := dockercompose.NewComposeFile(dockerComposeFile)
-	dockerCompose := composeFile.Config()
+	composeFile := dockercompose.Read(dockerComposeFile)
 
 	//determine which docker-compose service/container to deploy
-	_, dockerService := getDockerServiceToDeploy(dockerCompose)
+	_, dockerService := getDockerServiceToDeploy(&composeFile.Data)
 	if dockerService == nil {
 		console.IssueExit(`Please indicate which docker container you'd like to deploy using the label "%s: 1"`, deployDockerComposeLabel)
 	}

--- a/cmd/service_deploy_test.go
+++ b/cmd/service_deploy_test.go
@@ -18,7 +18,8 @@ services:
     build: .
     image: 1234567890.dkr.ecr.us-east-1.amazonaws.com/my-service:0.1.0
     ports:
-    - "80:8080"
+    - published: 80
+      target: 8080
     environment:
       FOO: bar
 `
@@ -50,7 +51,8 @@ services:
     build: .
     image: 1234567890.dkr.ecr.us-east-1.amazonaws.com/my-service:0.1.0
     ports:
-    - "80:8080"
+    - published: 80
+      target: 8080
     environment:
       FOO: bar
     labels:
@@ -86,7 +88,8 @@ services:
     build: .
     image: 1234567890.dkr.ecr.us-east-1.amazonaws.com/my-service:0.1.0
     ports:
-    - "80:8080"
+    - published: 80
+      target: 8080
     environment:
       FOO: bar
   redis:

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -10,6 +10,7 @@ var taskCmd = &cobra.Command{
 	Use:   "task",
 	Short: "Manage tasks",
 	Long: `Manage tasks
+	
 Tasks are one-time executions of your container. Instances of your task are run
 until you manually stop them either through AWS APIs, the AWS Management
 Console, or until they are interrupted for any reason.`,

--- a/cmd/task_generate.go
+++ b/cmd/task_generate.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/turnerlabs/fargate/console"
+	"github.com/turnerlabs/fargate/dockercompose"
+	ECS "github.com/turnerlabs/fargate/ecs"
+)
+
+var flagTaskGenerateDockerComposeFile string
+
+var taskGenerateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate a docker compose file based on a task definition",
+	Run:   generate,
+	Example: `
+# with a fargate.yml present	
+fargate task generate
+
+# specify task definition family, and compose file
+fargate task generate -t task -f docker-compose.yml
+
+# specify specific task definition family with revision
+fargate task generate -t my-app:42
+`,
+}
+
+func init() {
+	taskGenerateCmd.Flags().StringVarP(&flagTaskGenerateDockerComposeFile, "file", "f", "docker-compose.yml", "Ouptut Docker Compose file")
+
+	taskCmd.AddCommand(taskGenerateCmd)
+}
+
+func generate(cmd *cobra.Command, args []string) {
+	ecs := ECS.New(sess, "")
+
+	//lookup latest/active task definition from family
+	td := ecs.DescribeTaskDefinition(getTaskName()).TaskDefinition
+	if len(td.ContainerDefinitions) == 0 {
+		console.IssueExit("No container found in task definition")
+	}
+	container := td.ContainerDefinitions[0]
+
+	//initialize a new compose file
+	composeFile := dockercompose.New(flagTaskGenerateDockerComposeFile)
+
+	//add service for the 1st container
+	service := composeFile.AddService(*container.Name)
+	service.Image = *container.Image
+
+	//ports
+	for _, p := range container.PortMappings {
+		service.Ports = append(service.Ports, dockercompose.Port{
+			Published: 80,
+			Target:    *p.ContainerPort,
+		})
+	}
+
+	//add envvars
+	for _, e := range container.Environment {
+		service.Environment[*e.Name] = *e.Value
+	}
+
+	//add secrets
+	for _, s := range container.Secrets {
+		service.Secrets[*s.Name] = *s.ValueFrom
+	}
+
+	//indicate that this container should be deployed
+	service.Labels[deployDockerComposeLabel] = "1"
+
+	//write object to file
+	yes := true
+	if _, err := os.Stat(composeFile.File); err == nil {
+		fmt.Print(composeFile.File + " already exists. Overwrite? ")
+		yes = askForConfirmation()
+	}
+	if yes {
+		composeFile.Write()
+		fmt.Println("wrote", composeFile.File)
+	}
+	fmt.Println("done")
+}

--- a/cmd/task_generate.go
+++ b/cmd/task_generate.go
@@ -54,7 +54,7 @@ func generate(cmd *cobra.Command, args []string) {
 	//ports
 	for _, p := range container.PortMappings {
 		service.Ports = append(service.Ports, dockercompose.Port{
-			Published: 80,
+			Published: *p.ContainerPort,
 			Target:    *p.ContainerPort,
 		})
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+)
+
+var okayResponses = []string{"y", "Y", "yes", "Yes", "YES"}
+var nokayResponses = []string{"n", "N", "no", "No", "NO"}
+
+// askForConfirmation uses Scanln to parse user input. A user must type in "yes" or "no" and
+// then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
+// confirmations. If the input is not recognized, it will ask again. The function does not return
+// until it gets a valid response from the user. Typically, you should use fmt to print out a question
+// before calling askForConfirmation. E.g. fmt.Println("WARNING: Are you sure? (yes/no)")
+func askForConfirmation() bool {
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if containsString(okayResponses, response) {
+		return true
+	} else if containsString(nokayResponses, response) {
+		return false
+	} else {
+		fmt.Println("Please type yes or no and then press enter:")
+		return askForConfirmation()
+	}
+}
+
+// containsString returns true iff slice contains element
+func containsString(slice []string, element string) bool {
+	return !(posString(slice, element) == -1)
+}
+
+// posString returns the first index of element in slice.
+// If slice does not contain element, returns -1.
+func posString(slice []string, element string) int {
+	for index, elem := range slice {
+		if elem == element {
+			return index
+		}
+	}
+	return -1
+}

--- a/dockercompose/main.go
+++ b/dockercompose/main.go
@@ -2,40 +2,65 @@ package dockercompose
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os/exec"
 
 	"github.com/turnerlabs/fargate/console"
 	yaml "gopkg.in/yaml.v2"
 )
 
-//ComposeFile ...
+//ComposeFile represents a docker-compose.yml file
+//that can be manipulated
 type ComposeFile struct {
 	File string
+	Data DockerCompose
 }
 
-//NewComposeFile ...
-func NewComposeFile(file string) ComposeFile {
-	return ComposeFile{
+//Read loads a docker-compose.yml file
+func Read(file string) ComposeFile {
+	result := ComposeFile{
 		File: file,
 	}
+	result.Read()
+	return result
+}
+
+//New returns an initialized compose file
+func New(file string) ComposeFile {
+	result := ComposeFile{
+		File: file,
+		Data: DockerCompose{
+			Version:  "3.7",
+			Services: make(map[string]*Service),
+		},
+	}
+	return result
 }
 
 // DockerCompose represents a docker-compose.yml file
 type DockerCompose struct {
+	Version  string              `yaml:"version"`
 	Services map[string]*Service `yaml:"services"`
+}
+
+// Port represents a port
+type Port struct {
+	Published int64 `yaml:"published"`
+	Target    int64 `yaml:"target"`
 }
 
 // Service represents a docker container
 type Service struct {
 	Image       string            `yaml:"image,omitempty"`
+	Ports       []Port            `yaml:"ports,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
-	Labels      map[string]string `yaml:"labels,omitempty"`
 	Secrets     map[string]string `yaml:"x-fargate-secrets,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
-//Config returns a DockerCompose representation of the file
-//note that all variable interpolations are fully rendered by the config command
-func (composeFile *ComposeFile) Config() *DockerCompose {
+//Read reads the data structure from the file
+//note that all variable interpolations are fully rendered
+func (composeFile *ComposeFile) Read() {
 	console.Debug("running docker-compose config [%s]", composeFile.File)
 	cmd := exec.Command("docker-compose", "-f", composeFile.File, "config")
 
@@ -58,5 +83,34 @@ func (composeFile *ComposeFile) Config() *DockerCompose {
 		console.ErrorExit(err, "error unmarshalling docker-compose.yml")
 	}
 
-	return &compose
+	composeFile.Data = compose
+}
+
+//AddService adds a service to a compose file
+func (composeFile *ComposeFile) AddService(name string) *Service {
+	result := &Service{}
+	result.Environment = make(map[string]string)
+	result.Labels = make(map[string]string)
+	result.Secrets = make(map[string]string)
+	result.Ports = []Port{}
+	composeFile.Data.Services[name] = result
+	return result
+}
+
+//Yaml returns the yaml for this compose file
+func (composeFile *ComposeFile) Yaml() ([]byte, error) {
+	return yaml.Marshal(composeFile.Data)
+}
+
+//Write writes the data to a file
+func (composeFile *ComposeFile) Write() error {
+	bits, err := composeFile.Yaml()
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(composeFile.File, bits, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION

```console
fargate task describe
```

The describe command describes a [Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) in [Docker Compose](https://docs.docker.com/compose/overview/) format. The Docker image, environment variables, secrets, and target port are the mapped elements.

This command can be useful for looking at changes made by the `task register`, `service deploy`, or `fargate service env set` commands.  It can also be useful for running a task definition locally for debugging or troubleshooting purposes.

```sh
fargate task describe -t my-app > docker-compose.yml
docker-compose up
```

You can specify the task definition family by using a `fargate.yml` file, the `FARGATE_TASK` envvar, or using 
the `-t` flag, including an optional revision number.

```sh
fargate task describe -t my-app
fargate task describe -t my-app:42
```

Example output:

```yaml
version: "3.7"
services:
  app:
    image: 1234567890.dkr.ecr.us-east-1.amazonaws.com/my-app:1.0
    ports:
    - published: 8080
      target: 8080
    environment:
      AWS_REGION: us-east-1
      ENVIRONMENT: dev
      FOO: bar
    x-fargate-secrets:
      KEY: arn:key:ssm:us-east-1:000000000000:parameter/path/to/my_parameter      
    labels:
      aws.ecs.fargate.deploy: "1"
```