### PR TITLE
Adds --wait-for-service flag to fargate service deploy

### DIFF
--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -76,7 +76,7 @@ func init() {
 
 	serviceDeployCmd.Flags().BoolVar(&flagServiceDeployDockerComposeImageOnly, "image-only", false, "Only deploy the image when a docker-compose.yml file is specified.")
 
-	serviceDeployCmd.Flags().BoolVar(&flagServiceDeployWaitForService, "wait-for-service", false, "Wait for the service to reach a steady state after deploying the new task definition.")
+	serviceDeployCmd.Flags().BoolVarP(&flagServiceDeployWaitForService, "wait-for-service", "w", false, "Wait for the service to reach a steady state after deploying the new task definition.")
 
 	serviceCmd.AddCommand(serviceDeployCmd)
 }

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -102,6 +102,8 @@ func deployService(operation *ServiceDeployOperation) {
 		service := ecs.DescribeService(operation.ServiceName)
 		if service.TaskDefinitionArn != taskDefinitionArn {
 			console.IssueExit("Stable revision %s does not match deployed revision %s", ecs.GetRevisionNumber(service.TaskDefinitionArn), ecs.GetRevisionNumber(taskDefinitionArn))
+		} else {
+			console.Info("Service %s has reached a steady state.", operation.ServiceName)
 		}
 	}
 }

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -89,7 +89,7 @@ func deployService(operation *ServiceDeployOperation) {
 	} else if operation.Revision != "" {
 		taskDefinitionArn = deployRevision(operation)
 	} else {
-		taskDefinitionArn = deployTaskDefinition(operation)
+		taskDefinitionArn = deployImage(operation)
 	}
 
 	if operation.WaitForService {
@@ -165,7 +165,7 @@ func deployRevision(operation *ServiceDeployOperation) string {
 	return taskDefinitionArn
 }
 
-func deployTaskDefinition(operation *ServiceDeployOperation) string {
+func deployImage(operation *ServiceDeployOperation) string {
 	ecs := ECS.New(sess, getClusterName())
 	service := ecs.DescribeService(operation.ServiceName)
 	taskDefinitionArn := ecs.UpdateTaskDefinitionImage(service.TaskDefinitionArn, operation.Image)

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -10,11 +10,12 @@ import (
 
 // ServiceDeployOperation represents a deploy operation
 type ServiceDeployOperation struct {
-	ServiceName string
-	Image       string
-	ComposeFile string
-	Region      string
-	Revision    string
+	ServiceName    string
+	Image          string
+	ComposeFile    string
+	Region         string
+	Revision       string
+	WaitForService bool
 }
 
 const deployDockerComposeLabel = "aws.ecs.fargate.deploy"
@@ -23,6 +24,7 @@ var flagServiceDeployImage string
 var flagServiceDeployDockerComposeFile string
 var flagServiceDeployDockerComposeImageOnly bool
 var flagServiceDeployRevision string
+var flagServiceDeployWaitForService bool
 
 var serviceDeployCmd = &cobra.Command{
 	Use:   "deploy",
@@ -48,11 +50,12 @@ fargate service deploy -r 37
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceDeployOperation{
-			ServiceName: getServiceName(),
-			Region:      region,
-			Image:       flagServiceDeployImage,
-			ComposeFile: flagServiceDeployDockerComposeFile,
-			Revision:    flagServiceDeployRevision,
+			ServiceName:    getServiceName(),
+			Region:         region,
+			Image:          flagServiceDeployImage,
+			ComposeFile:    flagServiceDeployDockerComposeFile,
+			Revision:       flagServiceDeployRevision,
+			WaitForService: flagServiceDeployWaitForService,
 		}
 
 		if !validateFlags(operation) {
@@ -72,6 +75,8 @@ func init() {
 	serviceDeployCmd.Flags().StringVarP(&flagServiceDeployDockerComposeFile, "file", "f", "", "Specify a docker-compose.yml file to deploy. The image and environment variables in the file will be deployed.")
 
 	serviceDeployCmd.Flags().BoolVar(&flagServiceDeployDockerComposeImageOnly, "image-only", false, "Only deploy the image when a docker-compose.yml file is specified.")
+
+	serviceDeployCmd.Flags().BoolVar(&flagServiceDeployWaitForService, "wait-for-service", false, "Wait for the service to reach a steady state after deploying the new task definition.")
 
 	serviceCmd.AddCommand(serviceDeployCmd)
 }

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -336,3 +336,16 @@ func (ecs *ECS) RestartService(serviceName string) {
 		console.ErrorExit(err, "Could not restart service")
 	}
 }
+
+func (ecs *ECS) WaitUntilServiceStable(serviceName string) {
+	err := ecs.svc.WaitUntilServicesStable(
+		&awsecs.DescribeServicesInput{
+			Cluster:  aws.String(ecs.ClusterName),
+			Services: aws.StringSlice([]string{serviceName}),
+		},
+	)
+
+	if err != nil {
+		console.ErrorExit(err, "Could not wait for ECS service to reach a steady state")
+	}
+}


### PR DESCRIPTION
Adds flag to `fargate service deploy` to wait for the newly deployed task to become stable before exiting.

One use case would be to allow a CI workflow to wait for the service to become fully deployed and healthy before continuing. 

This currently supports services that use the ECS deployment controller. Some extra work would need to be done for services that use blue/green deployments with CodeDeploy.

```
--wait-for-service   Wait for the service to reach a steady state after deploying the new task definition.
```

```
$ fargate service deploy --wait-for-service -r 41

[i] Deployed revision 41 to service my-app-dev.
[i] Waiting for service my-app-dev to reach a steady state...
[i] Service my-app-dev has reached a steady state.
```

Once the service is stable, if the stable revision does not match the deployed revision the cmd will exit with an error:

```
$ fargate service deploy --wait-for-service -r 40

[i] Deployed revision 40 to service my-app-dev.
[i] Waiting for service my-app-dev to reach a steady state...
[!] Stable revision 41 does not match deployed revision 40
```

If the request times out before reaching a steady state the cmd will exit with an error:
```
$ fargate service deploy --wait-for-service -f docker-compose.yml

[i] Deployed docker-compose.yml to service my-app-dev as revision 42
[i] Waiting for service my-app-dev to reach a steady state...
[!] Could not wait for ECS service to reach a steady state
ResourceNotReady: exceeded wait attempts
```