### PR TITLE
get rid of docker-compose shell out

### DIFF
--- a/cmd/task_register.go
+++ b/cmd/task_register.go
@@ -8,7 +8,7 @@ import (
 )
 
 var flagTaskRegisterImage string
-var flagTaskRegisterDockerComposeFile string
+var flagTaskRegisterDockerComposeFile []string
 var flagTaskRegisterEnvVars []string
 var flagTaskRegisterEnvFile string
 var flagTaskRegisterSecretVars []string
@@ -21,7 +21,7 @@ type taskRegisterOperation struct {
 	Image       string
 	EnvVars     []string
 	EnvFile     string
-	ComposeFile string
+	ComposeFile []string
 	SecretVars  []string
 	SecretFile  string
 }
@@ -49,8 +49,8 @@ var taskRegisterCmd = &cobra.Command{
 			len(flagTaskRegisterSecretVars) > 0 ||
 			flagTaskRegisterSecretFile != "")
 
-		if (flagTaskRegisterDockerComposeFile != "" && nonComposeOptions) ||
-			(flagTaskRegisterDockerComposeFile == "" && !nonComposeOptions) {
+		if (len(flagTaskRegisterDockerComposeFile) > 0 && nonComposeOptions) ||
+			(len(flagTaskRegisterDockerComposeFile) == 0 && !nonComposeOptions) {
 			cmd.Help()
 			return
 		}
@@ -74,7 +74,7 @@ func init() {
 
 	taskRegisterCmd.Flags().StringVar(&flagTaskRegisterEnvFile, "env-file", "", "File containing list of environment variables to set, one per line, of the form KEY=value")
 
-	taskRegisterCmd.Flags().StringVarP(&flagTaskRegisterDockerComposeFile, "file", "f", "", "Docker Compose file containing image and environment variables to register.")
+	taskRegisterCmd.Flags().StringArrayVarP(&flagTaskRegisterDockerComposeFile, "file", "f", []string{}, "Docker Compose file containing image and environment variables to register.")
 
 	taskRegisterCmd.Flags().StringArrayVar(&flagTaskRegisterSecretVars, "secret", []string{}, "Secret variables to set [e.g. --secret KEY=valueFrom --secret KEY2=valueFrom]")
 
@@ -91,7 +91,7 @@ func registerTask(op taskRegisterOperation) {
 	var secrets []ECS.Secret
 	replaceVars := false
 
-	if op.ComposeFile != "" {
+	if len(op.ComposeFile) > 0 {
 		dockerService := getDockerServiceFromComposeFile(op.ComposeFile)
 		image = dockerService.Image
 		envvars = convertDockerComposeEnvVarsToECSEnvVars(dockerService)

--- a/dockercompose/main.go
+++ b/dockercompose/main.go
@@ -1,10 +1,10 @@
 package dockercompose
 
 import (
-	"bytes"
 	"io/ioutil"
-	"os/exec"
 
+	"github.com/compose-spec/compose-go/loader"
+	compose "github.com/compose-spec/compose-go/types"
 	"github.com/turnerlabs/fargate/console"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -12,12 +12,12 @@ import (
 //ComposeFile represents a docker-compose.yml file
 //that can be manipulated
 type ComposeFile struct {
-	File string
+	File []string
 	Data DockerCompose
 }
 
 //Read loads a docker-compose.yml file
-func Read(file string) ComposeFile {
+func Read(file []string) ComposeFile {
 	result := ComposeFile{
 		File: file,
 	}
@@ -28,7 +28,7 @@ func Read(file string) ComposeFile {
 //New returns an initialized compose file
 func New(file string) ComposeFile {
 	result := ComposeFile{
-		File: file,
+		File: []string{file},
 		Data: DockerCompose{
 			Version:  "3.7",
 			Services: make(map[string]*Service),
@@ -41,28 +41,60 @@ func New(file string) ComposeFile {
 //note that all variable interpolations are fully rendered
 func (composeFile *ComposeFile) Read() {
 	console.Debug("running docker-compose config [%s]", composeFile.File)
-	cmd := exec.Command("docker-compose", "-f", composeFile.File, "config")
 
-	var outbuf, errbuf bytes.Buffer
-	cmd.Stdout = &outbuf
-	cmd.Stderr = &errbuf
-
-	if err := cmd.Start(); err != nil {
-		console.ErrorExit(err, errbuf.String())
+	//Load Docker Compose yaml
+	dcy, err := loadCompose(composeFile.File)
+	if err != nil {
+		console.ErrorExit(err, "error loading docker-compose yaml files")
 	}
 
-	if err := cmd.Wait(); err != nil {
-		console.IssueExit(errbuf.String())
-	}
-
+	console.Info(string(dcy))
 	//unmarshal the yaml
 	var compose DockerCompose
-	err := yaml.Unmarshal(outbuf.Bytes(), &compose)
+	err = yaml.Unmarshal(dcy, &compose)
 	if err != nil {
 		console.ErrorExit(err, "error unmarshalling docker-compose.yml")
 	}
 
 	composeFile.Data = compose
+}
+
+// Load and merge the docker-compose yaml files into one
+func loadCompose(files []string) ([]byte, error) {
+	var composeConfigFiles []compose.ConfigFile
+	for _, f := range files {
+		file, err := ioutil.ReadFile(f)
+		if err != nil {
+			return nil, err
+		}
+		composeConfig, err := loader.ParseYAML(file)
+		if err != nil {
+			return nil, err
+		}
+		composeConfigFiles = append(composeConfigFiles, compose.ConfigFile{Filename: f, Config: composeConfig})
+
+	}
+	dc, err := loader.Load(compose.ConfigDetails{
+		ConfigFiles: composeConfigFiles,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	y, err := yaml.Marshal(dc)
+
+	var remap map[string]interface{}
+	err = yaml.Unmarshal(y, &remap)
+
+	remap["version"] = composeConfigFiles[0].Config["version"]
+
+	y, err = yaml.Marshal(remap)
+	if err != nil {
+		return nil, err
+	}
+
+	return y, nil
+
 }
 
 //AddService adds a service to a compose file
@@ -87,7 +119,7 @@ func (composeFile *ComposeFile) Write() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(composeFile.File, bits, 0644)
+	err = ioutil.WriteFile(composeFile.File[0], bits, 0644)
 	if err != nil {
 		return err
 	}

--- a/dockercompose/main_test.go
+++ b/dockercompose/main_test.go
@@ -6,7 +6,7 @@ import (
 
 func doTest(t *testing.T, f string) ComposeFile {
 	//round-trip unmarshal and marshal
-	file := Read(f)
+	file := Read([]string{f})
 	b, e := file.Yaml()
 	if e != nil {
 		t.Error(e)
@@ -24,45 +24,6 @@ const (
 	secretKey     = "QUX"
 	secretValue   = "arn:key:ssm:us-east-1:000000000000:parameter/path/to/my_parameter"
 )
-
-// 2
-func TestComposeV2(t *testing.T) {
-	f := doTest(t, "v2.yml")
-	svc := f.Data.Services["web"]
-	if svc.Image != image {
-		t.Error("expecting image")
-	}
-	if svc.Ports[0].Published != publishedPort {
-		t.Error("expecting published port")
-	}
-	if svc.Ports[0].Target != targetPort {
-		t.Error("expecting published port")
-	}
-	if svc.Labels[labelKey] != labelValue {
-		t.Error("expecting label")
-	}
-}
-
-// 2.4
-func TestComposeV24(t *testing.T) {
-	f := doTest(t, "v2.4.yml")
-	svc := f.Data.Services["web"]
-	if svc.Image != image {
-		t.Error("expecting image")
-	}
-	if svc.Ports[0].Published != publishedPort {
-		t.Error("expecting published port")
-	}
-	if svc.Ports[0].Target != targetPort {
-		t.Error("expecting published port")
-	}
-	if svc.Labels[labelKey] != labelValue {
-		t.Error("expecting label")
-	}
-	if svc.Secrets[secretKey] != secretValue {
-		t.Error("expecting secret")
-	}
-}
 
 // 3.2 short
 func TestComposeV32Short(t *testing.T) {


### PR DESCRIPTION
I was working on getting rid of the docker-compose shell out and also allowing to pass in multiple docker-compose files so they can be merged which would allow for an inheritance model for fargate deploys.  Removing the dependency on docker-compse also allows for easier install.  The inclusion of the compose-spec library also would allow the fargate cli to more easily extend that spec.  

There is a problem that the compose-spec library only supports v3+, which  I didn't realize would be an issue while developing this.  They supposedly support v2 but the Load function fails the tests for v2 ( removed in this PR ). https://github.com/compose-spec/compose-spec/issues/12
 
Didn't know if it would be useful, so just throwing it up any way. 