### PR TITLE
Add sa-east-1 region

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ var validRegions = []string{
 	"ap-northeast-1",
 	"ap-northheast-2",
 	"ap-south-1",
+	"sa-east-1",
 }
 
 var (


### PR DESCRIPTION
This PR is intended to add the region `sa-east-1` to the list of `validRegions`.