### PR TITLE
Support newer compose spec

### DIFF
--- a/dockercompose/main.go
+++ b/dockercompose/main.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 
-	"github.com/turnerlabs/fargate/console"
+//	"github.com/turnerlabs/fargate/console"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -20,9 +21,11 @@ type ComposeFile struct {
 
 //Read loads a docker-compose.yml file
 func Read(file string) (ComposeFile, error) {
+  fmt.Fprintf(os.Stderr, "Reading file '%s'\n", file);
 	result := ComposeFile{
 		File: file,
 	}
+  fmt.Fprintf(os.Stderr, "Created result, about to call Read()", file);
 	var err error
 	err = result.Read()
 	return result, err
@@ -33,7 +36,6 @@ func New(file string) ComposeFile {
 	result := ComposeFile{
 		File: file,
 		Data: DockerCompose{
-			Version:  "3.7",
 			Services: make(map[string]*Service),
 		},
 	}
@@ -43,7 +45,7 @@ func New(file string) ComposeFile {
 //Read reads the data structure from the file
 //note that all variable interpolations are fully rendered
 func (composeFile *ComposeFile) Read() error {
-	console.Debug("running docker-compose config [%s]", composeFile.File)
+	fmt.Fprintf(os.Stderr, "running docker-compose config [%s]", composeFile.File)
 	cmd := exec.Command("docker-compose", "-f", composeFile.File, "config")
 
 	var outbuf, errbuf bytes.Buffer
@@ -65,7 +67,7 @@ func (composeFile *ComposeFile) Read() error {
 	if err != nil {
 		return fmt.Errorf("unmarshalling docker compose yaml: %w", err)
 	}
-	if compose.Version == "" || len(compose.Services) == 0 {
+	if len(compose.Services) == 0 {
 		return errors.New("unable to parse compose file")
 	}
 	composeFile.Data = compose

--- a/dockercompose/types.go
+++ b/dockercompose/types.go
@@ -9,8 +9,8 @@ import (
 
 // DockerCompose represents a docker-compose.yml file
 type DockerCompose struct {
-	Version  string              `yaml:"version"`
 	Services map[string]*Service `yaml:"services"`
+	Networks map[string]*Network `yaml:"networks"`
 }
 
 // Service represents a docker container
@@ -22,15 +22,21 @@ type Service struct {
 	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
+// Service represents a docker network
+type Network struct {
+	Name        string             `yaml:"name,omitempty"`
+}
+
 // Port represents a port
 type Port struct {
 	Published int64 `yaml:"published"`
 	Target    int64 `yaml:"target"`
+	Mode      string `yaml:"mode"`
+	Protocol  string `yaml:"protocol"`
 }
 
 // used to parse the short syntax
 type dockerComposeShortPortSyntax struct {
-	Version  string                             `yaml:"version"`
 	Services map[string]*serviceShortPortSyntax `yaml:"services"`
 }
 
@@ -58,7 +64,6 @@ func UnmarshalComposeYAML(yamlBytes []byte) (DockerCompose, error) {
 	if err == nil {
 
 		//copy data from short types to result types
-		result.Version = short.Version
 		result.Services = make(map[string]*Service, len(short.Services))
 		for s, svc := range short.Services {
 

--- a/dockercompose/types.go
+++ b/dockercompose/types.go
@@ -9,6 +9,7 @@ import (
 
 // DockerCompose represents a docker-compose.yml file
 type DockerCompose struct {
+	Version  string              `yaml:"version,omitempty"`
 	Services map[string]*Service `yaml:"services"`
 	Networks map[string]*Network `yaml:"networks"`
 }
@@ -37,6 +38,7 @@ type Port struct {
 
 // used to parse the short syntax
 type dockerComposeShortPortSyntax struct {
+	Version  string                             `yaml:"version,omitempty"`
 	Services map[string]*serviceShortPortSyntax `yaml:"services"`
 }
 


### PR DESCRIPTION
This allows the dockercompose module to parse the output of the v2-enabled `docker-compose config` command, which notably omits the top-level version property that the logic was previously checking for.