### PR TITLE
Service connect ENI bug

### DIFF
--- a/ecs/task.go
+++ b/ecs/task.go
@@ -16,6 +16,7 @@ const (
 	detailSubnetId            = "subnetId"
 	startedByFormat           = "fargate:%s"
 	taskGroupStartedByPattern = "fargate:(.*)"
+	eniAttachmentType         = "ElasticNetworkInterface"
 )
 
 type Task struct {
@@ -228,13 +229,18 @@ func (ecs *ECS) DescribeTasks(taskIds []string) []Task {
 			)
 		}
 
-		if len(t.Attachments) == 1 {
-			for _, detail := range t.Attachments[0].Details {
-				switch aws.StringValue(detail.Name) {
-				case detailNetworkInterfaceId:
-					task.EniId = aws.StringValue(detail.Value)
-				case detailSubnetId:
-					task.SubnetId = aws.StringValue(detail.Value)
+		if len(t.Attachments) > 0 {
+			for _, attachment := range t.Attachments {
+				if *attachment.Type != eniAttachmentType {
+					continue
+				}
+				for _, detail := range attachment.Details {
+					switch aws.StringValue(detail.Name) {
+					case detailNetworkInterfaceId:
+						task.EniId = aws.StringValue(detail.Value)
+					case detailSubnetId:
+						task.SubnetId = aws.StringValue(detail.Value)
+					}
 				}
 			}
 		}

--- a/ecs/task_test.go
+++ b/ecs/task_test.go
@@ -1,0 +1,113 @@
+package ecs
+
+import (
+	"testing"
+
+	awsecs "github.com/aws/aws-sdk-go/service/ecs"
+)
+
+// Test behavior for when there are no eni details
+func TestDetermineENIDetails_Empty(t *testing.T) {
+	taskResult := awsecs.Task{
+		Attachments: make([]*awsecs.Attachment, 0),
+	}
+
+	found, _, _ := determineENIDetails(&taskResult)
+
+	if found {
+		t.Error("The blank attachment should not find an eni")
+	}
+}
+
+// Test behavior for one simple eni attachment
+func TestDetermineENIDetails_SimpleENI(t *testing.T) {
+	taskResult := awsecs.Task{
+		Attachments: make([]*awsecs.Attachment, 1),
+	}
+
+	taskResult.Attachments[0] = &awsecs.Attachment{
+		Details: make([]*awsecs.KeyValuePair, 2),
+	}
+
+	var expectedSubnetName, expectedENIName = detailSubnetId, detailNetworkInterfaceId
+	var expectedSubnet, expectedENIID = "abc", "123"
+	var eniType = eniAttachmentType
+
+	taskResult.Attachments[0].Type = &eniType
+	taskResult.Attachments[0].Details[0] = &awsecs.KeyValuePair{
+		Name:  &expectedSubnetName,
+		Value: &expectedSubnet,
+	}
+	taskResult.Attachments[0].Details[1] = &awsecs.KeyValuePair{
+		Name:  &expectedENIName,
+		Value: &expectedENIID,
+	}
+
+	found, eniResult, subnetResult := determineENIDetails(&taskResult)
+
+	if !found {
+		t.Error("The blank attachment should find an eni")
+	}
+
+	if eniResult != expectedENIID {
+		t.Errorf("Should find ENIID. Was %s expected %s", eniResult, expectedENIID)
+	}
+
+	if subnetResult != expectedSubnet {
+		t.Errorf("Should find subnetid. Was %s expected %s", subnetResult, expectedSubnet)
+	}
+}
+
+// Test behavior for when there are multiple attachments, the first being ENI, then Service Connect
+func TestDetermineENIDetails_ServiceConnect(t *testing.T) {
+	taskResult := awsecs.Task{
+		Attachments: make([]*awsecs.Attachment, 2),
+	}
+
+	taskResult.Attachments[0] = &awsecs.Attachment{
+		Details: make([]*awsecs.KeyValuePair, 2),
+	}
+
+	taskResult.Attachments[1] = &awsecs.Attachment{
+		Details: make([]*awsecs.KeyValuePair, 2),
+	}
+
+	var expectedSubnetName, expectedENIName = detailSubnetId, detailNetworkInterfaceId
+	var expectedSubnet, expectedENIID = "abc", "123"
+	var notExpectedSubnet, noExpectedENIID = "xyz", "456"
+	var eniType, serviceConnectType = eniAttachmentType, "Service Connect"
+
+	taskResult.Attachments[0].Type = &eniType
+	taskResult.Attachments[0].Details[0] = &awsecs.KeyValuePair{
+		Name:  &expectedSubnetName,
+		Value: &expectedSubnet,
+	}
+	taskResult.Attachments[0].Details[1] = &awsecs.KeyValuePair{
+		Name:  &expectedENIName,
+		Value: &expectedENIID,
+	}
+
+	taskResult.Attachments[1].Type = &serviceConnectType
+	taskResult.Attachments[1].Details[0] = &awsecs.KeyValuePair{
+		Name:  &expectedSubnetName,
+		Value: &notExpectedSubnet,
+	}
+	taskResult.Attachments[1].Details[1] = &awsecs.KeyValuePair{
+		Name:  &expectedENIName,
+		Value: &noExpectedENIID,
+	}
+
+	found, eniResult, subnetResult := determineENIDetails(&taskResult)
+
+	if !found {
+		t.Error("The blank attachment should find an eni")
+	}
+
+	if eniResult != expectedENIID {
+		t.Errorf("Should find ENIID. Was %s expected %s", eniResult, expectedENIID)
+	}
+
+	if subnetResult != expectedSubnet {
+		t.Errorf("Should find subnetid. Was %s expected %s", subnetResult, expectedSubnet)
+	}
+}


### PR DESCRIPTION
When a service had ECS Service Connect enabled, it listed an extra item in the Attachments struct. The code was specifically only expecting one item. Now it can handle more than one Attachment and correctly pick the network interface values. At the moment AWS only allows one network interface, so the new method should work and in the future will just return the last one listed in Attachments:

https://docs.aws.amazon.com/AmazonECS/latest/userguide/fargate-task-networking.html

I refactored the code that determines the networking details into its own function and added 3 unit tests for the various situations.

I know that there is not an easy way to spin up a fargate cluster with Service Connect just for testing, but anyone helping with testing should at least make sure that any existing functionality still works. This code is used by `service info` and `service ps` in particular.